### PR TITLE
Fix build

### DIFF
--- a/SetupAttributes.h
+++ b/SetupAttributes.h
@@ -136,7 +136,7 @@
 #define ZERO_BUILDNUM
 #endif
 
-#define BUILD_DRIVER_VERSION(major,minor,buildnum) major"."minor"."buildnum
+#define BUILD_DRIVER_VERSION(major,minor,buildnum) major "." minor "." buildnum
 #ifdef __BORLANDC__
 #define BUILD_VERSION_STR(major,minor,revno,buildnum) major "." minor "." "0" "." buildnum
 #else


### PR DESCRIPTION
In file included from ../../IscDbc/IscDatabaseMetaData.cpp:47:
../../IscDbc/IscDatabaseMetaData.cpp: In member function ‘virtual const char* IscDbcLibrary::IscDatabaseMetaData::getDriverVersion()’:
../../IscDbc/../SetupAttributes.h:139:65: error: inconsistent user-defined literal suffixes ‘minor’ and ‘buildnum’ in string literal
 #define BUILD_DRIVER_VERSION(major,minor,buildnum) major"."minor"."buildnum
                                                                 ^~~~~~~~~~~
../../IscDbc/../SetupAttributes.h:150:25: note: in expansion of macro ‘BUILD_DRIVER_VERSION’
 #define DRIVER_VERSION  BUILD_DRIVER_VERSION( ZERO_MAJOR BUILD_STR2( MAJOR_VERSION ), ZERO_MINOR BUILD_STR2( MINOR_VERSION ), ZERO_BUILDNUM BUILD_STR2( BUILDNUM_VERSION ) )
                         ^~~~~~~~~~~~~~~~~~~~
../../IscDbc/IscDatabaseMetaData.cpp:350:9: note: in expansion of macro ‘DRIVER_VERSION’
  return DRIVER_VERSION;
         ^~~~~~~~~~~~~~
../../IscDbc/../SetupAttributes.h:139:65: error: unable to find string literal operator ‘operator""minor’ with ‘const char [5]’, ‘long unsigned int’ arguments
 #define BUILD_DRIVER_VERSION(major,minor,buildnum) major"."minor"."buildnum
                                                                 ^~~~~~~~~~~
../../IscDbc/../SetupAttributes.h:150:25: note: in expansion of macro ‘BUILD_DRIVER_VERSION’
 #define DRIVER_VERSION  BUILD_DRIVER_VERSION( ZERO_MAJOR BUILD_STR2( MAJOR_VERSION ), ZERO_MINOR BUILD_STR2( MINOR_VERSION ), ZERO_BUILDNUM BUILD_STR2( BUILDNUM_VERSION ) )
                         ^~~~~~~~~~~~~~~~~~~~
../../IscDbc/IscDatabaseMetaData.cpp:350:9: note: in expansion of macro ‘DRIVER_VERSION’
  return DRIVER_VERSION;
         ^~~~~~~~~~~~~~