### PR TITLE
Fixes macros to be compatible with C++11 compilers

### DIFF
--- a/SetupAttributes.h
+++ b/SetupAttributes.h
@@ -136,7 +136,7 @@
 #define ZERO_BUILDNUM
 #endif
 
-#define BUILD_DRIVER_VERSION(major,minor,buildnum) major"."minor"."buildnum
+#define BUILD_DRIVER_VERSION(major,minor,buildnum) major "." minor "." buildnum
 #ifdef __BORLANDC__
 #define BUILD_VERSION_STR(major,minor,revno,buildnum) major "." minor "." "0" "." buildnum
 #else


### PR DESCRIPTION
Since the introduction of user-defined literals, the code that uses format macro constants for fixed-width integer types with no space after the preceding string literal became invalid. 
For example:

`std::printf("%"PRId64"\n",INT64_MIN);`
has to be replaced by 
`std::printf("%" PRId64"\n",INT64_MIN);`

This PR fixes the build using an updated GCC compiler:
```
#14 0.561 In file included from ../../IscDbc/IscDatabaseMetaData.cpp:47:
#14 0.561 ../../IscDbc/IscDatabaseMetaData.cpp: In member function 'virtual const char* IscDbcLibrary::IscDatabaseMetaData::getDriverVersion()':
#14 0.561 ../../IscDbc/../SetupAttributes.h:139:65: error: inconsistent user-defined literal suffixes 'minor' and 'buildnum' in string literal
#14 0.561   139 | #define BUILD_DRIVER_VERSION(major,minor,buildnum) major"."minor"."buildnum
#14 0.561       |                                                                 ^~~~~~~~~~~
#14 0.561 ../../IscDbc/../SetupAttributes.h:150:33: note: in expansion of macro 'BUILD_DRIVER_VERSION'
```
