### PR TITLE
Issue #214 : New FB4-5 types compatibility. Build 3.0.0.8

### DIFF
--- a/IscDbc/Attachment.h
+++ b/IscDbc/Attachment.h
@@ -49,6 +49,7 @@ public:
 	void loadClientLiblary( Properties *properties );
 	bool isFirebirdVer2_0(){ return majorFb == 2; }
 	void createDatabase(const char *dbName, Properties *properties);
+	void setLegacyBindingsForFB4_5();
 	void openDatabase(const char * dbName, Properties * properties);
 	Attachment();
 	~Attachment();

--- a/IscDbc/IscColumnsResultSet.h
+++ b/IscDbc/IscColumnsResultSet.h
@@ -37,6 +37,7 @@ class IscColumnsResultSet : public IscMetaDataResultSet
 public:
 	virtual bool nextFetch();
 	void getColumns(const char * catalog, const char * schemaPattern, const char * tableNamePattern, const char * fieldNamePattern);
+	void LegacyTypesConversion();
 	IscColumnsResultSet(IscDatabaseMetaData *metaData);
 	void initResultSet(IscStatement *stmt);
 private:

--- a/WriteBuildNo.h
+++ b/WriteBuildNo.h
@@ -4,4 +4,4 @@
 // Note - there must be two tabs between BUILDNUM_VERSION and 
 // the actual number, otherwise the makefile for linux will not
 // pick up the value.
-#define BUILDNUM_VERSION		7
+#define BUILDNUM_VERSION		8


### PR DESCRIPTION
Attention! Since decfloats, int128, etc types are still not supported by ODBC standard, this patch does NOT implement a complete new FB types integration, but only allows to use them in compatibility mode. The solution is that ODBC driver automatically adds "set bind of ... to legacy" directives on DB attachment.
- int128-like types are binded as varchar;
- decfloats are binded as double prec (pure legacy);
- with-time-zone types are binded as without timezone (pure legacy).