### PR TITLE
Keep the driver from removing quotes from rdb$field_source, so consumers get qotes if they are necessary.

### DIFF
--- a/IscDbc/IscColumnsResultSet.cpp
+++ b/IscDbc/IscColumnsResultSet.cpp
@@ -290,11 +290,14 @@ bool IscColumnsResultSet::getDefSource (int indexIn, int indexTarget)
 	while ( *++beg == ' ' );
 	while ( *end == ' ' ) end--;
 
-	if ( *beg == '\'' && *(beg + 1) != '\'' )
+	// This removes quotes that are necessary. So it is commented out.
+	/*
+	if (*beg == '\'' && *(beg + 1) != '\'')
 	{
 		++beg;
 		--end;
 	}
+	*/
 
 	*end = '\0';
 	


### PR DESCRIPTION
Keep the driver from removing quotes from rdb$field_source, so consumers get qotes if they are necessary.

Possibly fixes #251 