### PR TITLE
Allow installing as x64compatible

### DIFF
--- a/Install/Win32/OdbcJdbcSetup.iss
+++ b/Install/Win32/OdbcJdbcSetup.iss
@@ -119,7 +119,7 @@ ArchitecturesInstallIn64BitMode=win64
 #if PlatformTarget == "x64"
 ArchitecturesAllowed=x64compatible
 #elif PlatformTarget == "ARM64"
-ArchitecturesAllowed=arm64
+ArchitecturesAllowed=arm64 x64compatible
 #elif PlatformTarget == "Win32"
 ArchitecturesAllowed=x86os
 #endif


### PR DESCRIPTION
This will alow installing x64compatible driver on ARM Windows with allows to use Firebird from applications running in x86 emulator on ARM.

Fixes issue: https://github.com/FirebirdSQL/firebird-odbc-driver/issues/262