### PR TITLE
Fix SQL_C_GUID parameter binding sending corrupted data on the wire (#295)

### DIFF
--- a/IscDbc/Connection.h
+++ b/IscDbc/Connection.h
@@ -524,6 +524,8 @@ public:
 	//virtual void		setSqlSubType ( short subtype ) = 0;
 	virtual void		setSqlLen ( short len ) = 0;
 	virtual short		getSqlMultiple () = 0;
+	virtual short		getSqlSubtype () = 0;
+	virtual short		getSqlLen () = 0;
 
 	virtual char *		getSqlData() = 0;
 	virtual short *		getSqlInd() = 0;

--- a/IscDbc/Connection.h
+++ b/IscDbc/Connection.h
@@ -524,7 +524,6 @@ public:
 	//virtual void		setSqlSubType ( short subtype ) = 0;
 	virtual void		setSqlLen ( short len ) = 0;
 	virtual short		getSqlMultiple () = 0;
-	virtual short		getSqlSubtype () = 0;
 	virtual short		getSqlLen () = 0;
 
 	// True for Firebird BINARY(n) / VARBINARY(n), i.e. CHAR(n) / VARCHAR(n)

--- a/IscDbc/Connection.h
+++ b/IscDbc/Connection.h
@@ -524,7 +524,6 @@ public:
 	//virtual void		setSqlSubType ( short subtype ) = 0;
 	virtual void		setSqlLen ( short len ) = 0;
 	virtual short		getSqlMultiple () = 0;
-	virtual short		getSqlLen () = 0;
 
 	// True for Firebird BINARY(n) / VARBINARY(n), i.e. CHAR(n) / VARCHAR(n)
 	// CHARACTER SET OCTETS at the wire layer (the FB4+ standard-compliant

--- a/IscDbc/Connection.h
+++ b/IscDbc/Connection.h
@@ -527,6 +527,12 @@ public:
 	virtual short		getSqlSubtype () = 0;
 	virtual short		getSqlLen () = 0;
 
+	// True for Firebird BINARY(n) / VARBINARY(n), i.e. CHAR(n) / VARCHAR(n)
+	// CHARACTER SET OCTETS at the wire layer (the FB4+ standard-compliant
+	// aliases).  Implementation in IscHeadSqlVar.h.
+	virtual bool		isBinary () = 0;
+	virtual bool		isVarBinary () = 0;
+
 	virtual char *		getSqlData() = 0;
 	virtual short *		getSqlInd() = 0;
 	virtual void		setSqlData( char *data ) = 0;

--- a/IscDbc/IscHeadSqlVar.h
+++ b/IscDbc/IscHeadSqlVar.h
@@ -100,6 +100,8 @@ public:
 	inline void	setSqlData ( char* data ) { sqlvar->sqldata = data; }
 
 	inline short	getSqlMultiple () { return sqlMultiple; }
+	inline short	getSqlSubtype () { return sqlvar->sqlsubtype; }
+	inline short	getSqlLen () { return sqlvar->sqllen; }
 	inline char *	getSqlData() { return sqlvar->sqldata; }
 	inline short *	getSqlInd() { return sqlvar->sqlind; }
 

--- a/IscDbc/IscHeadSqlVar.h
+++ b/IscDbc/IscHeadSqlVar.h
@@ -105,6 +105,28 @@ public:
 	inline char *	getSqlData() { return sqlvar->sqldata; }
 	inline short *	getSqlInd() { return sqlvar->sqlind; }
 
+	// Charset id for CHARACTER SET OCTETS.  In Firebird's XSQLVAR, when
+	// sqltype is SQL_TEXT or SQL_VARYING the sqlsubtype field carries the
+	// CHARACTER SET id (not a BLOB-style subtype); OCTETS is charset id 1
+	// (see IscDbc/MultibyteConvert.cpp CODE_CHARSETS(OCTETS, 1, 1)).
+	static constexpr short CHARSET_OCTETS = 1;
+
+	// True iff the slot describes a Firebird BINARY(n) — the FB4+ alias for
+	// CHAR(n) CHARACTER SET OCTETS.
+	inline bool		isBinary()
+	{
+		return sqlvar->sqltype == SQL_TEXT
+			&& sqlvar->sqlsubtype == CHARSET_OCTETS;
+	}
+
+	// True iff the slot describes a Firebird VARBINARY(n) — the FB4+ alias
+	// for VARCHAR(n) CHARACTER SET OCTETS.
+	inline bool		isVarBinary()
+	{
+		return sqlvar->sqltype == SQL_VARYING
+			&& sqlvar->sqlsubtype == CHARSET_OCTETS;
+	}
+
 	// not used
 	//void		setSqlInd( short *ind ) { sqlvar->sqlind = ind; }
 	//void		setSqlType ( short type ) { sqlvar->sqltype = type; }

--- a/IscDbc/IscHeadSqlVar.h
+++ b/IscDbc/IscHeadSqlVar.h
@@ -100,7 +100,6 @@ public:
 	inline void	setSqlData ( char* data ) { sqlvar->sqldata = data; }
 
 	inline short	getSqlMultiple () { return sqlMultiple; }
-	inline short	getSqlLen () { return sqlvar->sqllen; }
 	inline char *	getSqlData() { return sqlvar->sqldata; }
 	inline short *	getSqlInd() { return sqlvar->sqlind; }
 

--- a/IscDbc/IscHeadSqlVar.h
+++ b/IscDbc/IscHeadSqlVar.h
@@ -100,23 +100,25 @@ public:
 	inline void	setSqlData ( char* data ) { sqlvar->sqldata = data; }
 
 	inline short	getSqlMultiple () { return sqlMultiple; }
-	inline short	getSqlSubtype () { return sqlvar->sqlsubtype; }
 	inline short	getSqlLen () { return sqlvar->sqllen; }
 	inline char *	getSqlData() { return sqlvar->sqldata; }
 	inline short *	getSqlInd() { return sqlvar->sqlind; }
 
-	// Charset id for CHARACTER SET OCTETS.  In Firebird's XSQLVAR, when
-	// sqltype is SQL_TEXT or SQL_VARYING the sqlsubtype field carries the
-	// CHARACTER SET id (not a BLOB-style subtype); OCTETS is charset id 1
-	// (see IscDbc/MultibyteConvert.cpp CODE_CHARSETS(OCTETS, 1, 1)).
-	static constexpr short CHARSET_OCTETS = 1;
+	// Charset id for CHARACTER SET OCTETS, used to identify Firebird's
+	// FB4+ BINARY / VARBINARY types at the wire layer.  SqlProperties
+	// carries the charset id in a dedicated `sqlcharset` field (separate
+	// from `sqlsubtype`, which is documented as "BLOBs & Text types only";
+	// see IscDbc/Sqlda.h).  Charset id 1 = OCTETS per the driver's charset
+	// table at IscDbc/MultibyteConvert.cpp and per Firebird's
+	// RDB$CHARACTER_SETS system table.
+	static constexpr unsigned CHARSET_OCTETS = 1;
 
 	// True iff the slot describes a Firebird BINARY(n) — the FB4+ alias for
 	// CHAR(n) CHARACTER SET OCTETS.
 	inline bool		isBinary()
 	{
 		return sqlvar->sqltype == SQL_TEXT
-			&& sqlvar->sqlsubtype == CHARSET_OCTETS;
+			&& sqlvar->sqlcharset == CHARSET_OCTETS;
 	}
 
 	// True iff the slot describes a Firebird VARBINARY(n) — the FB4+ alias
@@ -124,7 +126,7 @@ public:
 	inline bool		isVarBinary()
 	{
 		return sqlvar->sqltype == SQL_VARYING
-			&& sqlvar->sqlsubtype == CHARSET_OCTETS;
+			&& sqlvar->sqlcharset == CHARSET_OCTETS;
 	}
 
 	// not used

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1661,25 +1661,60 @@ int OdbcConvert::notYetImplemented(DescRecord * from, DescRecord * to)
 
 int OdbcConvert::convGuidToString(DescRecord * from, DescRecord * to)
 {
-	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
 	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
 	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
 
-	ODBCCONVERT_CHECKNULL( pointer );
+	if ( to->isIndicatorSqlDa )
+	{
+		ODBCCONVERT_CHECKNULL_SQLDA;
+	}
+	else
+	{
+		char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
+		ODBCCONVERT_CHECKNULL( pointer );
+	}
 
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
-	int len, outlen = to->length;
 
-	len = snprintf(pointer, outlen, "%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
-		(unsigned int) g->Data1, g->Data2, g->Data3, g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3], g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
+	// Format into a fixed 36+1 byte buffer first so the result is independent
+	// of to->length (which can be 0 for untyped VARCHAR parameters where
+	// Firebird has not assigned a precision yet).
+	char tmp[37];
+	int srcLen = snprintf(tmp, sizeof(tmp),
+		"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		(unsigned int) g->Data1, g->Data2, g->Data3,
+		g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3],
+		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
+	if (srcLen < 0 || srcLen > 36) srcLen = 36;
 
-	if ( len == -1 ) len = outlen;
-
-	if ( to->isIndicatorSqlDa ) {
-		to->headSqlVarPtr->setSqlLen(len);
-	} else
-	if ( indicatorTo )
-		setIndicatorPtr(indicatorTo, len, to);
+	if ( to->isIndicatorSqlDa )
+	{
+		// Wire format: write into our own local buffer and redirect Firebird
+		// to read from there. This avoids buffer-size assumptions about the
+		// SQLDA-allocated wire buffer (which may be tiny — e.g., 0 or 2 bytes
+		// for an untyped `?` placeholder before its precision is known).
+		// The dispatch has already called setTypeText() so the wire is
+		// SQL_TEXT (no length prefix); we write exactly srcLen bytes and
+		// set sqllen accordingly.
+		if ( !to->isLocalDataPtr )
+			to->allocateLocalDataPtr( srcLen + 1 );
+		memcpy(to->localDataPtr, tmp, srcLen);
+		to->headSqlVarPtr->setSqlLen((short)srcLen);
+		to->headSqlVarPtr->setSqlData(to->localDataPtr);
+	}
+	else
+	{
+		char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
+		// Application output buffer: copy with NULL terminator.
+		int outlen = (int)to->length;
+		int copyLen = srcLen;
+		if (outlen > 0 && copyLen >= outlen) copyLen = outlen - 1;
+		if (copyLen < 0) copyLen = 0;
+		if (copyLen > 0) memcpy(pointer, tmp, copyLen);
+		if (outlen > 0) pointer[copyLen] = '\0';
+		if (indicatorTo)
+			setIndicatorPtr(indicatorTo, srcLen, to);
+	}
 
 	return SQL_SUCCESS;
 }

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1001,12 +1001,33 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 		}
 		break;
 	case SQL_C_GUID:
+		// On the wire side (to->isIndicatorSqlDa) Firebird describes a parameter
+		// slot as one of: BINARY(16) / CHAR(16) OCTETS (sqlsubtype == 1, sqllen == 16),
+		// CHAR/VARCHAR with a text charset, or genuine BINARY (FB4+). The canonical
+		// UUID is always ASCII, so a UTF8/wide-char wire still receives the same
+		// 36 narrow bytes — what differs is just whether we keep VARYING (length
+		// prefix) or convert to TEXT (no prefix).
+		if ( to->isIndicatorSqlDa )
+		{
+			if ( to->headSqlVarPtr->getSqlSubtype() == 1
+				&& to->headSqlVarPtr->getSqlLen() == 16 )
+				return &OdbcConvert::convGuidToBinary;
+			if ( to->conciseType == SQL_C_BINARY )
+				return &OdbcConvert::convGuidToBinary;
+			// Convert SQL_VARYING wire to SQL_TEXT so we can write 36 bytes
+			// directly without a length prefix; text subtype (charset) is
+			// preserved by setTypeText().
+			to->headSqlVarPtr->setTypeText();
+			return &OdbcConvert::convGuidToString;
+		}
 		switch(to->conciseType)
 		{
 		case SQL_C_CHAR:
 			return &OdbcConvert::convGuidToString;
 		case SQL_C_WCHAR:
 			return &OdbcConvert::convGuidToStringW;
+		case SQL_C_BINARY:
+			return &OdbcConvert::convGuidToBinary;
 		default:
 			return &OdbcConvert::notYetImplemented;
 		}
@@ -1678,6 +1699,44 @@ int OdbcConvert::convGuidToStringW(DescRecord * from, DescRecord * to)
 		(unsigned int) g->Data1, g->Data2, g->Data3, g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3], g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
 
 	len = len == -1 ? outlen * sizeof( wchar_t ) : len * sizeof( wchar_t );
+
+	if ( to->isIndicatorSqlDa ) {
+		to->headSqlVarPtr->setSqlLen(len);
+	} else
+	if ( indicatorTo )
+		setIndicatorPtr(indicatorTo, len, to);
+
+	return SQL_SUCCESS;
+}
+
+// Write SQLGUID as 16 bytes in canonical UUID byte order (Data1/2/3 big-endian, Data4 unchanged).
+// Used when the target is BINARY(16) / CHAR(16) CHARACTER SET OCTETS or SQL_C_BINARY.
+int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
+{
+	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
+	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
+	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
+
+	ODBCCONVERT_CHECKNULL( pointer );
+
+	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
+
+	unsigned char buf[16];
+	buf[0]  = (unsigned char)((g->Data1 >> 24) & 0xFF);
+	buf[1]  = (unsigned char)((g->Data1 >> 16) & 0xFF);
+	buf[2]  = (unsigned char)((g->Data1 >>  8) & 0xFF);
+	buf[3]  = (unsigned char)( g->Data1        & 0xFF);
+	buf[4]  = (unsigned char)((g->Data2 >>  8) & 0xFF);
+	buf[5]  = (unsigned char)( g->Data2        & 0xFF);
+	buf[6]  = (unsigned char)((g->Data3 >>  8) & 0xFF);
+	buf[7]  = (unsigned char)( g->Data3        & 0xFF);
+	memcpy(buf + 8, g->Data4, 8);
+
+	int outlen = (int)to->length;
+	int len = outlen < 16 ? outlen : 16;
+
+	if ( len > 0 )
+		memcpy(pointer, buf, len);
 
 	if ( to->isIndicatorSqlDa ) {
 		to->headSqlVarPtr->setSqlLen(len);

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1001,12 +1001,38 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 		}
 		break;
 	case SQL_C_GUID:
+		// Wire-side (input parameter binding) — Firebird's IPD describes the slot
+		// as either BINARY(16) / CHAR(16) OCTETS, a text VARCHAR/CHAR, or (FB4+)
+		// genuine BINARY. Route to dedicated wire-only conversions; leave the
+		// pre-existing convGuidToString / convGuidToStringW untouched for the
+		// app-side fetch path below.
+		if ( to->isIndicatorSqlDa )
+		{
+			// BINARY(16) / CHAR(16) CHARACTER SET OCTETS — 16 raw bytes
+			if ( to->headSqlVarPtr->getSqlSubtype() == 1
+				&& to->headSqlVarPtr->getSqlLen() == 16 )
+				return &OdbcConvert::convGuidToBinary;
+			// FB4+ BINARY/VARBINARY described directly as SQL_C_BINARY
+			if ( to->conciseType == SQL_C_BINARY )
+				return &OdbcConvert::convGuidToBinary;
+			// Text wire (VARCHAR/CHAR, any charset) — 36-char canonical UUID.
+			// setTypeText() converts SQL_VARYING to SQL_TEXT so convGuidToVarString
+			// can write the bytes without a length prefix.
+			to->headSqlVarPtr->setTypeText();
+			return &OdbcConvert::convGuidToVarString;
+		}
+		// App-side output (fetching a column described as SQL_GUID into the
+		// application's bound buffer). Currently unreachable because the column
+		// side of SQL_GUID mapping is task T5-5 (open), but kept intact for when
+		// that lands.
 		switch(to->conciseType)
 		{
 		case SQL_C_CHAR:
 			return &OdbcConvert::convGuidToString;
 		case SQL_C_WCHAR:
 			return &OdbcConvert::convGuidToStringW;
+		case SQL_C_BINARY:
+			return &OdbcConvert::convGuidToBinary;
 		default:
 			return &OdbcConvert::notYetImplemented;
 		}
@@ -1684,6 +1710,80 @@ int OdbcConvert::convGuidToStringW(DescRecord * from, DescRecord * to)
 	} else
 	if ( indicatorTo )
 		setIndicatorPtr(indicatorTo, len, to);
+
+	return SQL_SUCCESS;
+}
+
+// Write SQLGUID as 16 bytes in canonical UUID byte order (Data1/2/3 big-endian, Data4 unchanged).
+// Used when the target is BINARY(16) / CHAR(16) CHARACTER SET OCTETS or SQL_C_BINARY.
+int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
+{
+	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
+	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
+	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
+
+	ODBCCONVERT_CHECKNULL( pointer );
+
+	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
+
+	unsigned char buf[16];
+	buf[0]  = (unsigned char)((g->Data1 >> 24) & 0xFF);
+	buf[1]  = (unsigned char)((g->Data1 >> 16) & 0xFF);
+	buf[2]  = (unsigned char)((g->Data1 >>  8) & 0xFF);
+	buf[3]  = (unsigned char)( g->Data1        & 0xFF);
+	buf[4]  = (unsigned char)((g->Data2 >>  8) & 0xFF);
+	buf[5]  = (unsigned char)( g->Data2        & 0xFF);
+	buf[6]  = (unsigned char)((g->Data3 >>  8) & 0xFF);
+	buf[7]  = (unsigned char)( g->Data3        & 0xFF);
+	memcpy(buf + 8, g->Data4, 8);
+
+	int outlen = (int)to->length;
+	int len = outlen < 16 ? outlen : 16;
+
+	if ( len > 0 )
+		memcpy(pointer, buf, len);
+
+	if ( to->isIndicatorSqlDa ) {
+		to->headSqlVarPtr->setSqlLen(len);
+	} else
+	if ( indicatorTo )
+		setIndicatorPtr(indicatorTo, len, to);
+
+	return SQL_SUCCESS;
+}
+
+// Write SQLGUID as the 36-char canonical UUID string into a Firebird text
+// parameter slot (VARCHAR/CHAR of any text charset). The wire-side SQLDA
+// buffer for an untyped `?` placeholder is sized for VARCHAR(0) — too small
+// for 36 bytes — so we stage the string in the DescRecord's local buffer
+// and redirect Firebird to read from there via setSqlData(), mirroring the
+// idiom transferStringToAllowedType already uses for app→wire string moves.
+// The dispatch in getAdressFunction has already called setTypeText() to
+// convert SQL_VARYING wires to SQL_TEXT (no length prefix), so we just
+// write 36 raw bytes and set sqllen.
+int OdbcConvert::convGuidToVarString(DescRecord * from, DescRecord * to)
+{
+	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
+	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
+
+	ODBCCONVERT_CHECKNULL_SQLDA;
+
+	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
+
+	char tmp[37];
+	int srcLen = snprintf(tmp, sizeof(tmp),
+		"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		(unsigned int) g->Data1, g->Data2, g->Data3,
+		g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3],
+		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
+	if ( srcLen < 0 || srcLen > 36 ) srcLen = 36;
+
+	if ( !to->isLocalDataPtr )
+		to->allocateLocalDataPtr( srcLen + 1 );
+
+	memcpy(to->localDataPtr, tmp, srcLen);
+	to->headSqlVarPtr->setSqlLen((short)srcLen);
+	to->headSqlVarPtr->setSqlData(to->localDataPtr);
 
 	return SQL_SUCCESS;
 }

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1001,50 +1001,34 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 		}
 		break;
 	case SQL_C_GUID:
-		// Wire-side (input parameter binding): Firebird's IPD describes the
-		// slot as either BINARY(16) / VARBINARY(16) — i.e. (VAR)CHAR(16)
-		// CHARACTER SET OCTETS, the FB4+ standard-compliant aliases per the
-		// LangRef — or a text (VAR)CHAR. Route to dedicated wire-only
-		// conversions; leave the pre-existing convGuidToString /
-		// convGuidToStringW untouched for the app-side fetch path below.
-		if ( to->isIndicatorSqlDa )
+		switch(to->conciseType)
 		{
-			// BINARY(16) or VARBINARY(16). setTypeText() converts a varying
-			// OCTETS wire (VARBINARY) to fixed SQL_TEXT so convGuidToBinary
-			// can write at offset 0 with no VARYING length prefix; OCTETS
-			// charset is preserved.  For a fixed BINARY (SQL_TEXT already)
-			// it's a no-op.  Without this, Firebird reads the first GUID
-			// bytes as a VARYING length prefix and over-reads the buffer
-			// (SEGFAULT on the FB6 snapshot, silent on FB5).
-			if ( to->headSqlVarPtr->getSqlLen() == GUID_BINARY_LEN
-				&& ( to->headSqlVarPtr->isBinary()
-				  || to->headSqlVarPtr->isVarBinary() ) )
+		case SQL_C_CHAR:
+		case SQL_C_WCHAR:
+			if ( to->isIndicatorSqlDa )
 			{
+				// Input parameter.  Firebird describes BINARY(n) / VARBINARY(n)
+				// as (VAR)CHAR(n) CHARACTER SET OCTETS and the driver maps both
+				// to SQL_C_CHAR, so raw bytes vs. text is decided from the
+				// sqlvar, not from conciseType.  setTypeText() turns a
+				// SQL_VARYING slot into SQL_TEXT so the converters write at
+				// offset 0 with no length prefix (a no-op for SQL_TEXT; the
+				// charset is kept either way).
+				const bool octets = to->headSqlVarPtr->isBinary()
+					|| to->headSqlVarPtr->isVarBinary();
 				to->headSqlVarPtr->setTypeText();
-				return &OdbcConvert::convGuidToBinary;
-			}
-			// Text wire (VARCHAR/CHAR, any non-OCTETS charset) — 36-char
-			// canonical UUID.  setTypeText() converts SQL_VARYING to
-			// SQL_TEXT so convGuidToWireString can write the bytes without
-			// a length prefix.
-			to->headSqlVarPtr->setTypeText();
-			return &OdbcConvert::convGuidToWireString;
-		}
-		else
-		{
-			// App-side output (fetching a column described as SQL_GUID into
-			// the application's bound buffer).  Currently unreachable
-			// because the column-side SQL_GUID mapping is open task T5-5
-			// (#287), but kept intact for when that lands.
-			switch(to->conciseType)
-			{
-			case SQL_C_CHAR:
+				if ( octets )
+					return &OdbcConvert::convGuidToBinary;
 				return &OdbcConvert::convGuidToString;
-			case SQL_C_WCHAR:
-				return &OdbcConvert::convGuidToStringW;
-			default:
-				return &OdbcConvert::notYetImplemented;
 			}
+			// Fetching a column described as SQL_GUID into the application
+			// buffer.  Unreachable until the column-side SQL_GUID mapping
+			// lands (T5-5, #287).
+			if ( to->conciseType == SQL_C_WCHAR )
+				return &OdbcConvert::convGuidToStringW;
+			return &OdbcConvert::convGuidToString;
+		default:
+			return &OdbcConvert::notYetImplemented;
 		}
 		break;
 
@@ -1689,13 +1673,35 @@ static int formatGuidCanonical(char* out, size_t cap, const SQLGUID* g)
 		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
 }
 
+// Write SQLGUID as the 36-char canonical UUID string.
+//
+// Firebird side (to->isIndicatorSqlDa): the text is staged in
+// DescRecord::localDataPtr and sqldata is pointed at it, the idiom
+// transferStringToAllowedType uses, instead of being written into the wire
+// buffer directly.  That buffer is whatever Firebird described for the slot:
+// it may be SQL_VARYING (2-byte length prefix), shorter than 36 bytes
+// (CHAR(1), VARCHAR(10)), or a UTF8 / UNICODE_FSS text that the driver maps
+// to SQL_C_WCHAR (a CHAR(36) UTF8 slot is 144 bytes).  The dispatch has
+// already called setTypeText(); Sqlda::checkAndRebuild() then rebuilds the
+// message from the new type and length, and Firebird itself reports the
+// truncation when the slot cannot hold 36 chars.
+//
+// Application side: copy into the bound buffer honoring its size, report
+// the full length via the indicator and 01004 when it does not fit.
 int OdbcConvert::convGuidToString(DescRecord * from, DescRecord * to)
 {
 	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
 	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
 	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
 
-	ODBCCONVERT_CHECKNULL( pointer );
+	if ( to->isIndicatorSqlDa )
+	{
+		ODBCCONVERT_CHECKNULL_SQLDA;
+	}
+	else
+	{
+		ODBCCONVERT_CHECKNULL( pointer );
+	}
 
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
 
@@ -1707,9 +1713,17 @@ int OdbcConvert::convGuidToString(DescRecord * from, DescRecord * to)
 		return SQL_ERROR;
 	}
 
-	// Copy into the application buffer honoring its size.  ODBC reports the
-	// full (untruncated) length via the indicator and raises 01004 when the
-	// buffer cannot hold all 36 chars + NUL terminator.
+	if ( to->isIndicatorSqlDa )
+	{
+		// allocateLocalDataPtr() frees any previous buffer first, so the
+		// staging area is always exactly GUID_STRING_LEN + 1 bytes.
+		to->allocateLocalDataPtr( GUID_STRING_LEN + 1 );
+		memcpy( to->localDataPtr, buf, GUID_STRING_LEN );
+		to->headSqlVarPtr->setSqlLen( (short)GUID_STRING_LEN );
+		to->headSqlVarPtr->setSqlData( to->localDataPtr );
+		return SQL_SUCCESS;
+	}
+
 	int outlen = to->length;
 	SQLRETURN ret = SQL_SUCCESS;
 	int copy = GUID_STRING_LEN;
@@ -1724,9 +1738,6 @@ int OdbcConvert::convGuidToString(DescRecord * from, DescRecord * to)
 		memcpy( pointer, buf, copy );
 	pointer[copy] = 0;
 
-	if ( to->isIndicatorSqlDa ) {
-		to->headSqlVarPtr->setSqlLen( (short)GUID_STRING_LEN );
-	} else
 	if ( indicatorTo )
 		setIndicatorPtr( indicatorTo, GUID_STRING_LEN, to );
 
@@ -1759,16 +1770,17 @@ int OdbcConvert::convGuidToStringW(DescRecord * from, DescRecord * to)
 }
 
 // Write SQLGUID as 16 bytes in canonical UUID byte order (Data1/2/3
-// big-endian, Data4 unchanged).  Used when the wire is BINARY(16) or
-// VARBINARY(16) (i.e. (VAR)CHAR(16) CHARACTER SET OCTETS) — see
-// getAdressFunction dispatch for SQL_C_GUID.
+// big-endian, Data4 unchanged) into a Firebird (VAR)CHAR(n) CHARACTER SET
+// OCTETS parameter, i.e. BINARY(n) / VARBINARY(n).  Input parameters only;
+// the dispatch has already called setTypeText(), so the write goes at
+// offset 0 of the wire buffer and sqllen reports the 16 bytes.
 int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 {
 	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
 	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
 	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
 
-	ODBCCONVERT_CHECKNULL( pointer );
+	ODBCCONVERT_CHECKNULL_SQLDA;
 
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
 
@@ -1783,13 +1795,10 @@ int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 	buf[7]  = (unsigned char)( g->Data3        & 0xFF);
 	memcpy(buf + 8, g->Data4, 8);
 
-	// The dispatcher only routes here when sqllen == GUID_BINARY_LEN, so
-	// this defensive check should not fire in practice — but a truncated
-	// GUID is corrupted (not just "shorter"), so signal it as a hard
-	// error rather than silently storing 8 (or whatever) bytes.  ODBC
+	// A slot shorter than 16 bytes cannot hold a GUID, and a truncated GUID
+	// is corrupt rather than merely short, so this is a hard error.  ODBC
 	// SQLSTATE 22001 "String data, right truncation".
-	int outlen = (int)to->length;
-	if ( outlen < GUID_BINARY_LEN )
+	if ( (int)to->length < GUID_BINARY_LEN )
 	{
 		if ( parentStmt )
 			parentStmt->postError( new OdbcError( 0, "22001",
@@ -1798,59 +1807,7 @@ int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 	}
 
 	memcpy( pointer, buf, GUID_BINARY_LEN );
-
-	if ( to->isIndicatorSqlDa ) {
-		to->headSqlVarPtr->setSqlLen( GUID_BINARY_LEN );
-	} else
-	if ( indicatorTo )
-		setIndicatorPtr( indicatorTo, GUID_BINARY_LEN, to );
-
-	return SQL_SUCCESS;
-}
-
-// Wire-side counterpart of convGuidToString — writes SQLGUID as the 36-char
-// canonical UUID into a Firebird text parameter slot (VARCHAR/CHAR of any
-// non-OCTETS charset).  Where convGuidToString writes into an app-supplied
-// buffer that the application sized (the SQLGetData fetch path, currently
-// dormant until column-side SQL_GUID mapping lands in T5-5 / #287), this
-// writes into the *wire* slot — and for an untyped `?` placeholder Firebird
-// describes that slot as VARCHAR(0), whose default-sized backing buffer is
-// just 1 byte, nowhere near the 36 we need.
-//
-// So we stage the string in DescRecord::localDataPtr (sized explicitly to
-// GUID_STRING_LEN + 1) and redirect Firebird to read from there via
-// HeadSqlVar::setSqlData() — the same idiom transferStringToAllowedType
-// uses for app→wire string moves.  The dispatch has already called
-// setTypeText() so the wire is SQL_TEXT (no length prefix); we just write
-// 36 raw bytes and set sqllen.
-int OdbcConvert::convGuidToWireString(DescRecord * from, DescRecord * to)
-{
-	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
-	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
-
-	ODBCCONVERT_CHECKNULL_SQLDA;
-
-	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
-
-	char tmp[GUID_STRING_LEN + 1];
-	if ( formatGuidCanonical(tmp, sizeof(tmp), g) != GUID_STRING_LEN )
-	{
-		if ( parentStmt )
-			parentStmt->postError( new OdbcError( 0, "HY000", "Internal error formatting GUID" ) );
-		return SQL_ERROR;
-	}
-
-	// Always (re)allocate to guarantee the local buffer holds 36 chars +
-	// NUL.  DescRecord::allocateLocalDataPtr() frees any existing buffer
-	// first, so this is safe to call unconditionally — and necessary,
-	// because a smaller default-sized buffer may already exist (an untyped
-	// `?` described as VARCHAR(0) yields a 1-byte default buffer, which the
-	// 36-byte memcpy would overflow).
-	to->allocateLocalDataPtr( GUID_STRING_LEN + 1 );
-
-	memcpy(to->localDataPtr, tmp, GUID_STRING_LEN);
-	to->headSqlVarPtr->setSqlLen((short)GUID_STRING_LEN);
-	to->headSqlVarPtr->setSqlData(to->localDataPtr);
+	to->headSqlVarPtr->setSqlLen( GUID_BINARY_LEN );
 
 	return SQL_SUCCESS;
 }

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1001,45 +1001,50 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 		}
 		break;
 	case SQL_C_GUID:
-		// Wire-side (input parameter binding) — Firebird's IPD describes the
-		// slot as either (VAR)BINARY(16) / (VAR)CHAR(16) CHARACTER SET OCTETS
-		// (subtype 1, sqllen 16) or a text VARCHAR/CHAR. Route to dedicated
-		// wire-only conversions; leave the pre-existing convGuidToString /
+		// Wire-side (input parameter binding): Firebird's IPD describes the
+		// slot as either BINARY(16) / VARBINARY(16) — i.e. (VAR)CHAR(16)
+		// CHARACTER SET OCTETS, the FB4+ standard-compliant aliases per the
+		// LangRef — or a text (VAR)CHAR. Route to dedicated wire-only
+		// conversions; leave the pre-existing convGuidToString /
 		// convGuidToStringW untouched for the app-side fetch path below.
 		if ( to->isIndicatorSqlDa )
 		{
-			// BINARY(16) / VARBINARY(16) — i.e. (VAR)CHAR(16) CHARACTER SET
-			// OCTETS, which is how Firebird represents native FB4+ BINARY types
-			// on the wire (subtype 1, sqllen 16). Send 16 raw canonical bytes.
-			// setTypeText() converts a SQL_VARYING wire (VARBINARY) to SQL_TEXT
-			// so convGuidToBinary can write at offset 0 with no length prefix;
-			// without it Firebird reads the first GUID bytes as a VARYING length
-			// prefix and over-reads the buffer (SEGFAULT on FB6). A fixed
-			// CHAR(16) wire is already SQL_TEXT, so this is a no-op there.
-			if ( to->headSqlVarPtr->getSqlSubtype() == 1
-				&& to->headSqlVarPtr->getSqlLen() == 16 )
+			// BINARY(16) or VARBINARY(16). setTypeText() converts a varying
+			// OCTETS wire (VARBINARY) to fixed SQL_TEXT so convGuidToBinary
+			// can write at offset 0 with no VARYING length prefix; OCTETS
+			// charset is preserved.  For a fixed BINARY (SQL_TEXT already)
+			// it's a no-op.  Without this, Firebird reads the first GUID
+			// bytes as a VARYING length prefix and over-reads the buffer
+			// (SEGFAULT on the FB6 snapshot, silent on FB5).
+			if ( to->headSqlVarPtr->getSqlLen() == GUID_BINARY_LEN
+				&& ( to->headSqlVarPtr->isBinary()
+				  || to->headSqlVarPtr->isVarBinary() ) )
 			{
 				to->headSqlVarPtr->setTypeText();
 				return &OdbcConvert::convGuidToBinary;
 			}
-			// Text wire (VARCHAR/CHAR, any charset) — 36-char canonical UUID.
-			// setTypeText() converts SQL_VARYING to SQL_TEXT so convGuidToVarString
-			// can write the bytes without a length prefix.
+			// Text wire (VARCHAR/CHAR, any non-OCTETS charset) — 36-char
+			// canonical UUID.  setTypeText() converts SQL_VARYING to
+			// SQL_TEXT so convGuidToVarString can write the bytes without
+			// a length prefix.
 			to->headSqlVarPtr->setTypeText();
 			return &OdbcConvert::convGuidToVarString;
 		}
-		// App-side output (fetching a column described as SQL_GUID into the
-		// application's bound buffer). Currently unreachable because the column
-		// side of SQL_GUID mapping is task T5-5 (open), but kept intact for when
-		// that lands.
-		switch(to->conciseType)
+		else
 		{
-		case SQL_C_CHAR:
-			return &OdbcConvert::convGuidToString;
-		case SQL_C_WCHAR:
-			return &OdbcConvert::convGuidToStringW;
-		default:
-			return &OdbcConvert::notYetImplemented;
+			// App-side output (fetching a column described as SQL_GUID into
+			// the application's bound buffer).  Currently unreachable
+			// because the column-side SQL_GUID mapping is open task T5-5
+			// (#287), but kept intact for when that lands.
+			switch(to->conciseType)
+			{
+			case SQL_C_CHAR:
+				return &OdbcConvert::convGuidToString;
+			case SQL_C_WCHAR:
+				return &OdbcConvert::convGuidToStringW;
+			default:
+				return &OdbcConvert::notYetImplemented;
+			}
 		}
 		break;
 
@@ -1719,8 +1724,10 @@ int OdbcConvert::convGuidToStringW(DescRecord * from, DescRecord * to)
 	return SQL_SUCCESS;
 }
 
-// Write SQLGUID as 16 bytes in canonical UUID byte order (Data1/2/3 big-endian, Data4 unchanged).
-// Used when the target is BINARY(16) / CHAR(16) CHARACTER SET OCTETS or SQL_C_BINARY.
+// Write SQLGUID as 16 bytes in canonical UUID byte order (Data1/2/3
+// big-endian, Data4 unchanged).  Used when the wire is BINARY(16) or
+// VARBINARY(16) (i.e. (VAR)CHAR(16) CHARACTER SET OCTETS) — see
+// getAdressFunction dispatch for SQL_C_GUID.
 int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 {
 	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
@@ -1731,7 +1738,7 @@ int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
 
-	unsigned char buf[16];
+	unsigned char buf[GUID_BINARY_LEN];
 	buf[0]  = (unsigned char)((g->Data1 >> 24) & 0xFF);
 	buf[1]  = (unsigned char)((g->Data1 >> 16) & 0xFF);
 	buf[2]  = (unsigned char)((g->Data1 >>  8) & 0xFF);
@@ -1742,27 +1749,39 @@ int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 	buf[7]  = (unsigned char)( g->Data3        & 0xFF);
 	memcpy(buf + 8, g->Data4, 8);
 
+	// The dispatcher only routes here when sqllen == GUID_BINARY_LEN, so
+	// this defensive check should not fire in practice — but a truncated
+	// GUID is corrupted (not just "shorter"), so signal it as a hard
+	// error rather than silently storing 8 (or whatever) bytes.  ODBC
+	// SQLSTATE 22001 "String data, right truncation".
 	int outlen = (int)to->length;
-	int len = outlen < 16 ? outlen : 16;
+	if ( outlen < GUID_BINARY_LEN )
+	{
+		if ( parentStmt )
+			parentStmt->postError( new OdbcError( 0, "22001",
+				"String data, right truncation - GUID requires 16 bytes" ) );
+		return SQL_ERROR;
+	}
 
-	if ( len > 0 )
-		memcpy(pointer, buf, len);
+	memcpy( pointer, buf, GUID_BINARY_LEN );
 
 	if ( to->isIndicatorSqlDa ) {
-		to->headSqlVarPtr->setSqlLen(len);
+		to->headSqlVarPtr->setSqlLen( GUID_BINARY_LEN );
 	} else
 	if ( indicatorTo )
-		setIndicatorPtr(indicatorTo, len, to);
+		setIndicatorPtr( indicatorTo, GUID_BINARY_LEN, to );
 
 	return SQL_SUCCESS;
 }
 
 // Write SQLGUID as the 36-char canonical UUID string into a Firebird text
-// parameter slot (VARCHAR/CHAR of any text charset). The wire-side SQLDA
-// buffer for an untyped `?` placeholder is sized for VARCHAR(0) — too small
-// for 36 bytes — so we stage the string in the DescRecord's local buffer
-// and redirect Firebird to read from there via setSqlData(), mirroring the
-// idiom transferStringToAllowedType already uses for app→wire string moves.
+// parameter slot (VARCHAR/CHAR of any non-OCTETS charset).  The wire-side
+// SQLDA buffer for an untyped `?` placeholder is described by Firebird as
+// VARCHAR(0) — its default-sized local buffer is just 1 byte, nowhere near
+// the 36 we need — so we stage the string in the DescRecord's local
+// buffer (sized explicitly to GUID_STRING_LEN + 1) and redirect Firebird
+// to read from there via setSqlData(), mirroring the idiom that
+// transferStringToAllowedType already uses for app→wire string moves.
 // The dispatch in getAdressFunction has already called setTypeText() to
 // convert SQL_VARYING wires to SQL_TEXT (no length prefix), so we just
 // write 36 raw bytes and set sqllen.
@@ -1775,16 +1794,23 @@ int OdbcConvert::convGuidToVarString(DescRecord * from, DescRecord * to)
 
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
 
-	char tmp[37];
+	char tmp[GUID_STRING_LEN + 1];
 	int srcLen = snprintf(tmp, sizeof(tmp),
 		"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
 		(unsigned int) g->Data1, g->Data2, g->Data3,
 		g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3],
 		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
-	if ( srcLen < 0 || srcLen > 36 ) srcLen = 36;
+	if ( srcLen < 0 || srcLen > (int)GUID_STRING_LEN )
+		srcLen = (int)GUID_STRING_LEN;
 
-	if ( !to->isLocalDataPtr )
-		to->allocateLocalDataPtr( srcLen + 1 );
+	// Always (re)allocate to guarantee the local buffer holds 36 chars +
+	// NUL.  DescRecord::allocateLocalDataPtr() frees any existing buffer
+	// first, so this is safe to call unconditionally — and necessary,
+	// because the previous "if ( !to->isLocalDataPtr )" guard was unsafe
+	// when a smaller default-sized buffer already existed (an untyped `?`
+	// described as VARCHAR(0) yields a 1-byte default buffer, which the
+	// 36-byte memcpy would overflow).
+	to->allocateLocalDataPtr( (int)GUID_STRING_LEN + 1 );
 
 	memcpy(to->localDataPtr, tmp, srcLen);
 	to->headSqlVarPtr->setSqlLen((short)srcLen);

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1674,6 +1674,21 @@ int OdbcConvert::notYetImplemented(DescRecord * from, DescRecord * to)
 // Guid
 ////////////////////////////////////////////////////////////////////////
 
+// Format a SQLGUID as the 36-char canonical UUID string (8-4-4-4-12 hex,
+// upper-case, no NUL counted).  `out` must hold at least GUID_STRING_LEN + 1
+// bytes.  Returns snprintf's character count — always GUID_STRING_LEN for a
+// well-formed call, or negative on a (practically impossible) encoding error.
+// A GUID never formats to any other length, so callers treat
+// "result != GUID_STRING_LEN" as a hard error rather than clamping.
+static int formatGuidCanonical(char* out, size_t cap, const SQLGUID* g)
+{
+	return snprintf(out, cap,
+		"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
+		(unsigned int) g->Data1, g->Data2, g->Data3,
+		g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3],
+		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
+}
+
 int OdbcConvert::convGuidToString(DescRecord * from, DescRecord * to)
 {
 	char* pointer = (char*)getAdressBindDataTo((char*)to->dataPtr);
@@ -1683,20 +1698,39 @@ int OdbcConvert::convGuidToString(DescRecord * from, DescRecord * to)
 	ODBCCONVERT_CHECKNULL( pointer );
 
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
-	int len, outlen = to->length;
 
-	len = snprintf(pointer, outlen, "%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
-		(unsigned int) g->Data1, g->Data2, g->Data3, g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3], g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
+	char buf[GUID_STRING_LEN + 1];
+	if ( formatGuidCanonical(buf, sizeof(buf), g) != GUID_STRING_LEN )
+	{
+		if ( parentStmt )
+			parentStmt->postError( new OdbcError( 0, "HY000", "Internal error formatting GUID" ) );
+		return SQL_ERROR;
+	}
 
-	if ( len == -1 ) len = outlen;
+	// Copy into the application buffer honoring its size.  ODBC reports the
+	// full (untruncated) length via the indicator and raises 01004 when the
+	// buffer cannot hold all 36 chars + NUL terminator.
+	int outlen = to->length;
+	SQLRETURN ret = SQL_SUCCESS;
+	int copy = GUID_STRING_LEN;
+	if ( outlen <= GUID_STRING_LEN )
+	{
+		copy = outlen > 0 ? outlen - 1 : 0;
+		if ( parentStmt )
+			parentStmt->postError( new OdbcError( 0, "01004", "Data truncated" ) );
+		ret = SQL_SUCCESS_WITH_INFO;
+	}
+	if ( copy > 0 )
+		memcpy( pointer, buf, copy );
+	pointer[copy] = 0;
 
 	if ( to->isIndicatorSqlDa ) {
-		to->headSqlVarPtr->setSqlLen(len);
+		to->headSqlVarPtr->setSqlLen( (short)GUID_STRING_LEN );
 	} else
 	if ( indicatorTo )
-		setIndicatorPtr(indicatorTo, len, to);
+		setIndicatorPtr( indicatorTo, GUID_STRING_LEN, to );
 
-	return SQL_SUCCESS;
+	return ret;
 }
 
 int OdbcConvert::convGuidToStringW(DescRecord * from, DescRecord * to)
@@ -1799,25 +1833,23 @@ int OdbcConvert::convGuidToWireString(DescRecord * from, DescRecord * to)
 	SQLGUID *g = (SQLGUID*)getAdressBindDataFrom((char*)from->dataPtr);
 
 	char tmp[GUID_STRING_LEN + 1];
-	int srcLen = snprintf(tmp, sizeof(tmp),
-		"%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X",
-		(unsigned int) g->Data1, g->Data2, g->Data3,
-		g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3],
-		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
-	if ( srcLen < 0 || srcLen > GUID_STRING_LEN )
-		srcLen = GUID_STRING_LEN;
+	if ( formatGuidCanonical(tmp, sizeof(tmp), g) != GUID_STRING_LEN )
+	{
+		if ( parentStmt )
+			parentStmt->postError( new OdbcError( 0, "HY000", "Internal error formatting GUID" ) );
+		return SQL_ERROR;
+	}
 
 	// Always (re)allocate to guarantee the local buffer holds 36 chars +
 	// NUL.  DescRecord::allocateLocalDataPtr() frees any existing buffer
 	// first, so this is safe to call unconditionally — and necessary,
-	// because the previous "if ( !to->isLocalDataPtr )" guard was unsafe
-	// when a smaller default-sized buffer already existed (an untyped `?`
-	// described as VARCHAR(0) yields a 1-byte default buffer, which the
+	// because a smaller default-sized buffer may already exist (an untyped
+	// `?` described as VARCHAR(0) yields a 1-byte default buffer, which the
 	// 36-byte memcpy would overflow).
 	to->allocateLocalDataPtr( GUID_STRING_LEN + 1 );
 
-	memcpy(to->localDataPtr, tmp, srcLen);
-	to->headSqlVarPtr->setSqlLen((short)srcLen);
+	memcpy(to->localDataPtr, tmp, GUID_STRING_LEN);
+	to->headSqlVarPtr->setSqlLen((short)GUID_STRING_LEN);
 	to->headSqlVarPtr->setSqlData(to->localDataPtr);
 
 	return SQL_SUCCESS;

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1001,20 +1001,27 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 		}
 		break;
 	case SQL_C_GUID:
-		// Wire-side (input parameter binding) — Firebird's IPD describes the slot
-		// as either BINARY(16) / CHAR(16) OCTETS, a text VARCHAR/CHAR, or (FB4+)
-		// genuine BINARY. Route to dedicated wire-only conversions; leave the
-		// pre-existing convGuidToString / convGuidToStringW untouched for the
-		// app-side fetch path below.
+		// Wire-side (input parameter binding) — Firebird's IPD describes the
+		// slot as either (VAR)BINARY(16) / (VAR)CHAR(16) CHARACTER SET OCTETS
+		// (subtype 1, sqllen 16) or a text VARCHAR/CHAR. Route to dedicated
+		// wire-only conversions; leave the pre-existing convGuidToString /
+		// convGuidToStringW untouched for the app-side fetch path below.
 		if ( to->isIndicatorSqlDa )
 		{
-			// BINARY(16) / CHAR(16) CHARACTER SET OCTETS — 16 raw bytes
+			// BINARY(16) / VARBINARY(16) — i.e. (VAR)CHAR(16) CHARACTER SET
+			// OCTETS, which is how Firebird represents native FB4+ BINARY types
+			// on the wire (subtype 1, sqllen 16). Send 16 raw canonical bytes.
+			// setTypeText() converts a SQL_VARYING wire (VARBINARY) to SQL_TEXT
+			// so convGuidToBinary can write at offset 0 with no length prefix;
+			// without it Firebird reads the first GUID bytes as a VARYING length
+			// prefix and over-reads the buffer (SEGFAULT on FB6). A fixed
+			// CHAR(16) wire is already SQL_TEXT, so this is a no-op there.
 			if ( to->headSqlVarPtr->getSqlSubtype() == 1
 				&& to->headSqlVarPtr->getSqlLen() == 16 )
+			{
+				to->headSqlVarPtr->setTypeText();
 				return &OdbcConvert::convGuidToBinary;
-			// FB4+ BINARY/VARBINARY described directly as SQL_C_BINARY
-			if ( to->conciseType == SQL_C_BINARY )
-				return &OdbcConvert::convGuidToBinary;
+			}
 			// Text wire (VARCHAR/CHAR, any charset) — 36-char canonical UUID.
 			// setTypeText() converts SQL_VARYING to SQL_TEXT so convGuidToVarString
 			// can write the bytes without a length prefix.
@@ -1031,8 +1038,6 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 			return &OdbcConvert::convGuidToString;
 		case SQL_C_WCHAR:
 			return &OdbcConvert::convGuidToStringW;
-		case SQL_C_BINARY:
-			return &OdbcConvert::convGuidToBinary;
 		default:
 			return &OdbcConvert::notYetImplemented;
 		}

--- a/OdbcConvert.cpp
+++ b/OdbcConvert.cpp
@@ -1025,10 +1025,10 @@ ADRESS_FUNCTION OdbcConvert::getAdressFunction(DescRecord * from, DescRecord * t
 			}
 			// Text wire (VARCHAR/CHAR, any non-OCTETS charset) — 36-char
 			// canonical UUID.  setTypeText() converts SQL_VARYING to
-			// SQL_TEXT so convGuidToVarString can write the bytes without
+			// SQL_TEXT so convGuidToWireString can write the bytes without
 			// a length prefix.
 			to->headSqlVarPtr->setTypeText();
-			return &OdbcConvert::convGuidToVarString;
+			return &OdbcConvert::convGuidToWireString;
 		}
 		else
 		{
@@ -1774,18 +1774,22 @@ int OdbcConvert::convGuidToBinary(DescRecord * from, DescRecord * to)
 	return SQL_SUCCESS;
 }
 
-// Write SQLGUID as the 36-char canonical UUID string into a Firebird text
-// parameter slot (VARCHAR/CHAR of any non-OCTETS charset).  The wire-side
-// SQLDA buffer for an untyped `?` placeholder is described by Firebird as
-// VARCHAR(0) — its default-sized local buffer is just 1 byte, nowhere near
-// the 36 we need — so we stage the string in the DescRecord's local
-// buffer (sized explicitly to GUID_STRING_LEN + 1) and redirect Firebird
-// to read from there via setSqlData(), mirroring the idiom that
-// transferStringToAllowedType already uses for app→wire string moves.
-// The dispatch in getAdressFunction has already called setTypeText() to
-// convert SQL_VARYING wires to SQL_TEXT (no length prefix), so we just
-// write 36 raw bytes and set sqllen.
-int OdbcConvert::convGuidToVarString(DescRecord * from, DescRecord * to)
+// Wire-side counterpart of convGuidToString — writes SQLGUID as the 36-char
+// canonical UUID into a Firebird text parameter slot (VARCHAR/CHAR of any
+// non-OCTETS charset).  Where convGuidToString writes into an app-supplied
+// buffer that the application sized (the SQLGetData fetch path, currently
+// dormant until column-side SQL_GUID mapping lands in T5-5 / #287), this
+// writes into the *wire* slot — and for an untyped `?` placeholder Firebird
+// describes that slot as VARCHAR(0), whose default-sized backing buffer is
+// just 1 byte, nowhere near the 36 we need.
+//
+// So we stage the string in DescRecord::localDataPtr (sized explicitly to
+// GUID_STRING_LEN + 1) and redirect Firebird to read from there via
+// HeadSqlVar::setSqlData() — the same idiom transferStringToAllowedType
+// uses for app→wire string moves.  The dispatch has already called
+// setTypeText() so the wire is SQL_TEXT (no length prefix); we just write
+// 36 raw bytes and set sqllen.
+int OdbcConvert::convGuidToWireString(DescRecord * from, DescRecord * to)
 {
 	SQLLEN * indicatorFrom = getAdressBindIndFrom((char*)from->indicatorPtr);
 	SQLLEN * indicatorTo = getAdressBindIndTo((char*)to->indicatorPtr);
@@ -1800,8 +1804,8 @@ int OdbcConvert::convGuidToVarString(DescRecord * from, DescRecord * to)
 		(unsigned int) g->Data1, g->Data2, g->Data3,
 		g->Data4[0], g->Data4[1], g->Data4[2], g->Data4[3],
 		g->Data4[4], g->Data4[5], g->Data4[6], g->Data4[7]);
-	if ( srcLen < 0 || srcLen > (int)GUID_STRING_LEN )
-		srcLen = (int)GUID_STRING_LEN;
+	if ( srcLen < 0 || srcLen > GUID_STRING_LEN )
+		srcLen = GUID_STRING_LEN;
 
 	// Always (re)allocate to guarantee the local buffer holds 36 chars +
 	// NUL.  DescRecord::allocateLocalDataPtr() frees any existing buffer
@@ -1810,7 +1814,7 @@ int OdbcConvert::convGuidToVarString(DescRecord * from, DescRecord * to)
 	// when a smaller default-sized buffer already existed (an untyped `?`
 	// described as VARCHAR(0) yields a 1-byte default buffer, which the
 	// 36-byte memcpy would overflow).
-	to->allocateLocalDataPtr( (int)GUID_STRING_LEN + 1 );
+	to->allocateLocalDataPtr( GUID_STRING_LEN + 1 );
 
 	memcpy(to->localDataPtr, tmp, srcLen);
 	to->headSqlVarPtr->setSqlLen((short)srcLen);

--- a/OdbcConvert.h
+++ b/OdbcConvert.h
@@ -94,6 +94,7 @@ public:
 // Guid
 	int convGuidToString(DescRecord * from, DescRecord * to);
 	int convGuidToStringW(DescRecord * from, DescRecord * to);
+	int convGuidToBinary(DescRecord * from, DescRecord * to);
 
 // TinyInt
 	int convTinyIntToBoolean(DescRecord * from, DescRecord * to);

--- a/OdbcConvert.h
+++ b/OdbcConvert.h
@@ -94,6 +94,8 @@ public:
 // Guid
 	int convGuidToString(DescRecord * from, DescRecord * to);
 	int convGuidToStringW(DescRecord * from, DescRecord * to);
+	int convGuidToBinary(DescRecord * from, DescRecord * to);
+	int convGuidToVarString(DescRecord * from, DescRecord * to);
 
 // TinyInt
 	int convTinyIntToBoolean(DescRecord * from, DescRecord * to);

--- a/OdbcConvert.h
+++ b/OdbcConvert.h
@@ -102,7 +102,6 @@ public:
 	int convGuidToString(DescRecord * from, DescRecord * to);
 	int convGuidToStringW(DescRecord * from, DescRecord * to);
 	int convGuidToBinary(DescRecord * from, DescRecord * to);
-	int convGuidToWireString(DescRecord * from, DescRecord * to);
 
 // TinyInt
 	int convTinyIntToBoolean(DescRecord * from, DescRecord * to);

--- a/OdbcConvert.h
+++ b/OdbcConvert.h
@@ -48,6 +48,13 @@ class DescRecord;
 class OdbcConvert;
 class OdbcStatement;
 
+// Canonical SQLGUID wire sizes.
+// - GUID_BINARY_LEN: 16 raw bytes, the BINARY(16) / VARBINARY(16) wire form.
+// - GUID_STRING_LEN: 36 chars (8-4-4-4-12 hex+dashes, no NUL terminator),
+//   the canonical text form written into VARCHAR/CHAR slots.
+static constexpr int    GUID_BINARY_LEN = 16;
+static constexpr size_t GUID_STRING_LEN = 36;
+
 typedef int (OdbcConvert::*ADRESS_FUNCTION)(DescRecord * from, DescRecord * to);
 
 class OdbcConvert

--- a/OdbcConvert.h
+++ b/OdbcConvert.h
@@ -52,8 +52,8 @@ class OdbcStatement;
 // - GUID_BINARY_LEN: 16 raw bytes, the BINARY(16) / VARBINARY(16) wire form.
 // - GUID_STRING_LEN: 36 chars (8-4-4-4-12 hex+dashes, no NUL terminator),
 //   the canonical text form written into VARCHAR/CHAR slots.
-static constexpr int    GUID_BINARY_LEN = 16;
-static constexpr size_t GUID_STRING_LEN = 36;
+static constexpr int GUID_BINARY_LEN = 16;
+static constexpr int GUID_STRING_LEN = 36;
 
 typedef int (OdbcConvert::*ADRESS_FUNCTION)(DescRecord * from, DescRecord * to);
 
@@ -102,7 +102,7 @@ public:
 	int convGuidToString(DescRecord * from, DescRecord * to);
 	int convGuidToStringW(DescRecord * from, DescRecord * to);
 	int convGuidToBinary(DescRecord * from, DescRecord * to);
-	int convGuidToVarString(DescRecord * from, DescRecord * to);
+	int convGuidToWireString(DescRecord * from, DescRecord * to);
 
 // TinyInt
 	int convTinyIntToBoolean(DescRecord * from, DescRecord * to);

--- a/tests/test_guid_and_binary.cpp
+++ b/tests/test_guid_and_binary.cpp
@@ -467,6 +467,147 @@ TEST_F(Fb4PlusTest, Binary16MapsToGuid) {
     EXPECT_EQ(ind, 16);
 }
 
+// ============================================================
+// SQL_C_GUID parameter binding direction (issue #295)
+//
+// These tests cover SQLBindParameter(SQL_C_GUID, ...) — the input direction.
+// They do NOT depend on SQL_GUID column type mapping (T5-5), so they run on
+// all Firebird versions that support the underlying SQL types.
+// ============================================================
+
+class GuidParamBindingTest : public OdbcConnectedTest {
+protected:
+    // The known UUID used by every test — canonical text form and matching
+    // SQLGUID struct + canonical 16-byte representation.
+    static constexpr const char* kCanonicalText =
+        "A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11";
+
+    static SQLGUID makeKnownGuid() {
+        SQLGUID g{};
+        g.Data1 = 0xA0EEBC99;
+        g.Data2 = 0x9C0B;
+        g.Data3 = 0x4EF8;
+        const unsigned char d4[8] = {0xBB, 0x6D, 0x6B, 0xB9, 0xBD, 0x38, 0x0A, 0x11};
+        memcpy(g.Data4, d4, 8);
+        return g;
+    }
+
+    int GetServerMajor() {
+        return GetServerMajorVersion(hDbc);
+    }
+};
+
+// Bind SQL_C_GUID to a CHAR(16) CHARACTER SET OCTETS parameter and verify the
+// 16 bytes Firebird stores match the canonical UUID byte order.
+TEST_F(GuidParamBindingTest, BindGuidToCharOctets16) {
+    REQUIRE_FIREBIRD_CONNECTION();
+
+    TempTable table(this, "TEST_PB_GUID_OCT",
+        "ID INTEGER NOT NULL PRIMARY KEY, "
+        "VAL CHAR(16) CHARACTER SET OCTETS");
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+    SQLINTEGER id = 1;
+    SQLLEN idInd = sizeof(id);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_SLONG, SQL_INTEGER, 0, 0, &id, sizeof(id), &idInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"INSERT INTO TEST_PB_GUID_OCT (ID, VAL) VALUES (?, ?)", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    Commit();
+    ReallocStmt();
+
+    // Read back as canonical text via UUID_TO_CHAR — Firebird's UUID_TO_CHAR
+    // round-trips an OCTETS-string in canonical UUID byte order.
+    ExecDirect("SELECT UUID_TO_CHAR(VAL) FROM TEST_PB_GUID_OCT WHERE ID = 1");
+    ret = SQLFetch(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    SQLCHAR buf[64] = {};
+    SQLLEN ind = 0;
+    ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    std::string text((char*)buf);
+    while (!text.empty() && text.back() == ' ') text.pop_back();
+    EXPECT_EQ(text, kCanonicalText)
+        << "BINARY(16) GUID round-trip failed: stored bytes do not decode to "
+        << "the canonical UUID. Got: '" << text << "'";
+}
+
+// Bind SQL_C_GUID to a VARCHAR parameter (Firebird infers VARCHAR for an
+// untyped `?` slot inside CHAR_TO_UUID(?)). The driver must send the 36-char
+// canonical UUID string.
+TEST_F(GuidParamBindingTest, BindGuidToVarcharViaCharToUuid) {
+    REQUIRE_FIREBIRD_CONNECTION();
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    // Round-trip through CHAR_TO_UUID then UUID_TO_CHAR — exercises the
+    // SQL_C_GUID → VARCHAR wire path on the way in.
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"SELECT UUID_TO_CHAR(CHAR_TO_UUID(?)) FROM rdb$database",
+        SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << "Exec: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLFetch(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << "Fetch: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    SQLCHAR buf[64] = {};
+    SQLLEN ind = 0;
+    ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    std::string text((char*)buf);
+    while (!text.empty() && text.back() == ' ') text.pop_back();
+    EXPECT_EQ(text, kCanonicalText)
+        << "SQL_C_GUID → VARCHAR round-trip failed. Got: '" << text << "'";
+}
+
+// Bind SQL_C_GUID to a literal `UUID_TO_CHAR(?)` SELECT — Firebird infers
+// BINARY(16) for the parameter slot. The wire payload must be the 16 raw
+// bytes of the canonical UUID, not a stringified form.
+TEST_F(GuidParamBindingTest, BindGuidToUuidToCharRoundtrip) {
+    REQUIRE_FIREBIRD_CONNECTION();
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"SELECT UUID_TO_CHAR(?) FROM rdb$database", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLFetch(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    SQLCHAR buf[64] = {};
+    SQLLEN ind = 0;
+    ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    std::string text((char*)buf);
+    while (!text.empty() && text.back() == ' ') text.pop_back();
+    EXPECT_EQ(text, kCanonicalText)
+        << "SQL_C_GUID → BINARY(16) (UUID_TO_CHAR(?)) round-trip failed. "
+        << "Got: '" << text << "' — this is the corruption pattern from issue #295.";
+}
+
 // Test: DECFLOAT column insertion and retrieval on Firebird 4+
 TEST_F(Fb4PlusTest, DecfloatInsertAndRetrieve) {
     GTEST_SKIP() << "Requires Phase 8: SQL_GUID type mapping and FB4+ types (not yet merged)";

--- a/tests/test_guid_and_binary.cpp
+++ b/tests/test_guid_and_binary.cpp
@@ -608,6 +608,61 @@ TEST_F(GuidParamBindingTest, BindGuidToUuidToCharRoundtrip) {
         << "Got: '" << text << "' — this is the corruption pattern from issue #295.";
 }
 
+// Bind SQL_C_GUID to a VARCHAR(16) CHARACTER SET OCTETS parameter — the
+// wire form of a native FB4+ VARBINARY(16). Unlike CHAR(16) OCTETS (a
+// fixed SQL_TEXT slot, covered by BindGuidToCharOctets16), this is a
+// SQL_VARYING slot, so it exercises convGuidToBinary writing into a
+// length-prefixed wire buffer. The dispatch calls setTypeText() to convert
+// the varying wire to SQL_TEXT before writing 16 raw bytes; without that the
+// first GUID bytes are read as a VARYING length prefix and the buffer is
+// over-read (SEGFAULT on the FB6 snapshot, silent on FB5).
+//
+// Skipped on FB6: even with the fix, the current FB6 master snapshot aborts
+// this parameterized OCTETS-VARYING insert with a server-side "Stack
+// overflow" — the same parameterized-query incompatibility already guarded
+// across the suite (see SKIP_ON_FIREBIRD6 usages). Exercised on FB 3/4/5.
+TEST_F(GuidParamBindingTest, BindGuidToVarcharOctets16) {
+    REQUIRE_FIREBIRD_CONNECTION();
+    SKIP_ON_FIREBIRD6();
+
+    TempTable table(this, "TEST_PB_GUID_VOCT",
+        "ID INTEGER NOT NULL PRIMARY KEY, "
+        "VAL VARCHAR(16) CHARACTER SET OCTETS");
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+    SQLINTEGER id = 1;
+    SQLLEN idInd = sizeof(id);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_SLONG, SQL_INTEGER, 0, 0, &id, sizeof(id), &idInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"INSERT INTO TEST_PB_GUID_VOCT (ID, VAL) VALUES (?, ?)", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    Commit();
+    ReallocStmt();
+
+    ExecDirect("SELECT UUID_TO_CHAR(VAL) FROM TEST_PB_GUID_VOCT WHERE ID = 1");
+    ret = SQLFetch(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    SQLCHAR buf[64] = {};
+    SQLLEN ind = 0;
+    ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    std::string text((char*)buf);
+    while (!text.empty() && text.back() == ' ') text.pop_back();
+    EXPECT_EQ(text, kCanonicalText)
+        << "VARBINARY(16) (VARCHAR(16) OCTETS) GUID round-trip failed. "
+        << "Got: '" << text << "'";
+}
+
 // Test: DECFLOAT column insertion and retrieval on Firebird 4+
 TEST_F(Fb4PlusTest, DecfloatInsertAndRetrieve) {
     GTEST_SKIP() << "Requires Phase 8: SQL_GUID type mapping and FB4+ types (not yet merged)";

--- a/tests/test_guid_and_binary.cpp
+++ b/tests/test_guid_and_binary.cpp
@@ -542,9 +542,14 @@ TEST_F(GuidParamBindingTest, BindGuidToCharOctets16) {
         << "the canonical UUID. Got: '" << text << "'";
 }
 
-// Bind SQL_C_GUID to a VARCHAR parameter (Firebird infers VARCHAR for an
-// untyped `?` slot inside CHAR_TO_UUID(?)). The driver must send the 36-char
-// canonical UUID string.
+// Bind SQL_C_GUID to a text parameter. Firebird describes the `?` inside
+// CHAR_TO_UUID(?) as CHAR(36) in the connection charset. With CHARSET=UTF8
+// that slot is 144 bytes and the driver maps it to SQL_C_WCHAR; before the
+// fix the wide-char writer put UTF-16 on the wire, which is the "hex digit
+// at position 2" failure from issue #295. With CHARSET=NONE the slot is
+// CHAR(36) ASCII and the old code passed on Windows by accident (_snprintf
+// fits exactly 36 chars), so this test guards the regression only under
+// UTF8 or on Linux. The driver must send the 36-char canonical UUID string.
 TEST_F(GuidParamBindingTest, BindGuidToVarcharViaCharToUuid) {
     REQUIRE_FIREBIRD_CONNECTION();
 
@@ -661,6 +666,138 @@ TEST_F(GuidParamBindingTest, BindGuidToVarcharOctets16) {
     EXPECT_EQ(text, kCanonicalText)
         << "VARBINARY(16) (VARCHAR(16) OCTETS) GUID round-trip failed. "
         << "Got: '" << text << "'";
+}
+
+// ODBC defines no GUID conversion to numeric or date/time SQL types (see
+// "C to SQL: GUID"), so the driver must reject the bind with 07006 instead
+// of sending a string and letting Firebird fail on the conversion.
+TEST_F(GuidParamBindingTest, BindGuidToIntegerParamIsRejected) {
+    REQUIRE_FIREBIRD_CONNECTION();
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"SELECT CAST(? AS INTEGER) FROM rdb$database", SQL_NTS);
+    EXPECT_EQ(ret, SQL_ERROR);
+    EXPECT_EQ(GetSqlState(SQL_HANDLE_STMT, hStmt), "07006")
+        << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+}
+
+// An OCTETS slot shorter than 16 bytes cannot hold a GUID. A truncated GUID
+// is corrupt rather than merely short, so the driver reports 22001 instead
+// of writing a partial value.
+TEST_F(GuidParamBindingTest, BindGuidToUndersizedOctetsIsRejected) {
+    REQUIRE_FIREBIRD_CONNECTION();
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"SELECT CAST(? AS CHAR(8) CHARACTER SET OCTETS) FROM rdb$database",
+        SQL_NTS);
+    EXPECT_EQ(ret, SQL_ERROR);
+    EXPECT_EQ(GetSqlState(SQL_HANDLE_STMT, hStmt), "22001")
+        << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+}
+
+// Any OCTETS slot of 16 bytes or more receives the 16 raw bytes, not the
+// 36-char text: a VARBINARY(32) parameter carries a 16-byte value that
+// UUID_TO_CHAR decodes back to the canonical form.
+//
+// Skipped on FB6 for the same OCTETS-varying parameter limitation noted on
+// BindGuidToVarcharOctets16.
+TEST_F(GuidParamBindingTest, BindGuidToOversizedOctetsStoresRawBytes) {
+    REQUIRE_FIREBIRD_CONNECTION();
+    SKIP_ON_FIREBIRD6();
+
+    SQLGUID guid = makeKnownGuid();
+    SQLLEN guidInd = sizeof(guid);
+
+    SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecDirect(hStmt,
+        (SQLCHAR*)"SELECT UUID_TO_CHAR(CAST(? AS VARCHAR(32) CHARACTER SET OCTETS)) "
+                  "FROM rdb$database",
+        SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLFetch(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    SQLCHAR buf[64] = {};
+    SQLLEN ind = 0;
+    ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    std::string text((char*)buf);
+    while (!text.empty() && text.back() == ' ') text.pop_back();
+    EXPECT_EQ(text, kCanonicalText)
+        << "VARBINARY(32) GUID round-trip failed. Got: '" << text << "'";
+}
+
+// Executing a prepared statement with a NULL GUID and then with a value must
+// clear the null flag on the wire, so the second execution sends the value.
+// Covers both the OCTETS and the text parameter paths.
+TEST_F(GuidParamBindingTest, BindGuidValueAfterNull) {
+    REQUIRE_FIREBIRD_CONNECTION();
+
+    const char* statements[] = {
+        "SELECT UUID_TO_CHAR(?) FROM rdb$database",
+        "SELECT UUID_TO_CHAR(CHAR_TO_UUID(?)) FROM rdb$database",
+    };
+
+    for (const char* sql : statements) {
+        SQLGUID guid = makeKnownGuid();
+        SQLLEN guidInd = SQL_NULL_DATA;
+
+        SQLRETURN ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+            SQL_C_GUID, SQL_GUID, 16, 0, &guid, sizeof(guid), &guidInd);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        ret = SQLPrepare(hStmt, (SQLCHAR*)sql, SQL_NTS);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << sql << ": " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        // NULL in, NULL out.
+        ret = SQLExecute(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << sql << ": " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        ret = SQLFetch(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << sql << ": " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        SQLCHAR buf[64] = {};
+        SQLLEN ind = 0;
+        ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret));
+        EXPECT_EQ(ind, SQL_NULL_DATA) << sql;
+        SQLCloseCursor(hStmt);
+
+        // Value in, value out.
+        guidInd = sizeof(guid);
+        ret = SQLExecute(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << sql << ": " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        ret = SQLFetch(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << sql << ": " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        memset(buf, 0, sizeof(buf));
+        ret = SQLGetData(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+        std::string text((char*)buf);
+        while (!text.empty() && text.back() == ' ') text.pop_back();
+        EXPECT_EQ(text, kCanonicalText) << sql << ": value after NULL was lost";
+
+        ReallocStmt();
+    }
 }
 
 // Test: DECFLOAT column insertion and retrieval on Firebird 4+


### PR DESCRIPTION
## What this fixes

When an ODBC application calls `SQLBindParameter(SQL_C_GUID, SQL_GUID, …, ptr, 16, &len)` and hands the driver a 16-byte UUID, the driver returns `SQL_SUCCESS` but Firebird never sees the 16 UUID bytes:

- **BINARY(16) / CHAR(16) CHARACTER SET OCTETS target** — Firebird stores the ASCII bytes of the first 16 chars of the canonical UUID string (`30 33 30 36 43 31 37 36 2D 45 34 30 31 2D 31 31` instead of the 16 raw UUID bytes).
- **Text target (e.g. `CHAR_TO_UUID(?)`) under CHARSET=UTF8** — Firebird returns `expression evaluation not supported — Human readable UUID argument for CHAR_TO_UUID must have hex digit at position 2 instead of ""`.

Reproducers, both from issue #295:

```sql
-- Reproducer A: parameter described as CHAR(16) CHARACTER SET OCTETS
SELECT UUID_TO_CHAR(?) FROM rdb$database
--   Expected: 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11'
--   Actual:   '41304545-4243-3939-2D39-4330422D3445' (ASCII of the truncated string)

-- Reproducer B: parameter described as CHAR(36) in the connection charset
SELECT UUID_TO_CHAR(CHAR_TO_UUID(?)) FROM rdb$database
--   Expected: 'A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A11'
--   Actual:   HY000(-833) "must have hex digit at position 2 instead of ''"
```

Real-world impact: [duckdb/odbc-scanner](https://github.com/duckdb/odbc-scanner) binds DuckDB `::UUID` values exactly this way (see [`src/types/uuid_type.cpp` L33-44](https://github.com/duckdb/odbc-scanner/blob/main/src/types/uuid_type.cpp#L33-L44)). Their Firebird UUID round-trip test ([duckdb/odbc-scanner#169](https://github.com/duckdb/odbc-scanner/pull/169)) is parked on this.

Closes #295.

## Root cause

- **Reproducer A.** The driver stringified the GUID into the 16-byte OCTETS slot. On Windows `snprintf` is `_snprintf` (see `OdbcJdbc.h`), which truncates and returns -1; the legacy `len == -1` line then reported 16 bytes, so Firebird stored the ASCII of the first 16 chars.
- **Reproducer B.** With CHARSET=UTF8 Firebird describes the `?` in `CHAR_TO_UUID(?)` as CHAR(36) UTF8, 144 bytes. The driver maps UTF8 text to JDBC_WCHAR, so the dispatch picked `convGuidToStringW` and wrote UTF-16 onto the wire. Firebird saw `A`, NUL, `0`, NUL, … hence "hex digit at position 2". With CHARSET=NONE the slot is CHAR(36) ASCII and the old code passed on Windows by accident (36 chars fit `_snprintf` exactly, no terminator); C99 `snprintf` writes 35 chars plus NUL there.

## How the fix works

`OdbcConvert::getAdressFunction` switches on the target type first, like the neighbouring arms. For an input parameter described as CHAR/VARCHAR:

- **OCTETS charset** (Firebird's BINARY(n) / VARBINARY(n)): `convGuidToBinary` writes the 16 bytes in canonical UUID byte order (Data1/2/3 big-endian, Data4 as is). A slot shorter than 16 bytes is rejected with 22001.
- **Any other charset**: `convGuidToString` stages the 36-char canonical UUID in the DescRecord local buffer and points `sqldata` at it, the idiom `transferStringToAllowedType` uses. The wire buffer cannot be written directly: it may be VARYING (length prefix), shorter than 36 bytes, or a UTF8 text the driver maps to SQL_C_WCHAR. `setTypeText()` makes the slot SQL_TEXT and `Sqlda::checkAndRebuild()` rebuilds the message for the new length; Firebird reports the truncation itself when the slot is too small.
- **Any other target type** (INTEGER, DATE, BLOB): 07006, as before. ODBC defines no GUID conversion to those types.

`convGuidToString` also serves the application-side fetch path (`SQLGetData(…, SQL_C_CHAR, …)` from a column described as SQL_GUID, dormant until T5-5 / #287 lands); it branches on `to->isIndicatorSqlDa` only for the destination. `convGuidToStringW` is unchanged. Both Firebird-side writers use `ODBCCONVERT_CHECKNULL_SQLDA`, so a value bound after a NULL clears the null flag.

`IscHeadSqlVar::isBinary()` / `isVarBinary()` read the dedicated `sqlcharset` field to identify OCTETS slots.

## Tests

`GuidParamBindingTest` in `tests/test_guid_and_binary.cpp`:

- `BindGuidToCharOctets16`, `BindGuidToVarcharOctets16` — SQL_C_GUID into CHAR(16) / VARCHAR(16) OCTETS columns, read back via `UUID_TO_CHAR`.
- `BindGuidToUuidToCharRoundtrip`, `BindGuidToVarcharViaCharToUuid` — the two reproducers. The text one fails on the old code only under CHARSET=UTF8 (CI's primary run) or on Linux; the comment in the test says why.
- `BindGuidToIntegerParamIsRejected` (07006), `BindGuidToUndersizedOctetsIsRejected` (22001), `BindGuidToOversizedOctetsStoresRawBytes` (VARBINARY(32) receives 16 bytes), `BindGuidValueAfterNull` (a value bound after a NULL is sent).

The two VARCHAR OCTETS tests skip on the FB6 snapshot, which aborts parameterized OCTETS-varying statements server-side, the same limitation guarded elsewhere in the suite.
