### PR TITLE
Fix numeric parameters silently sent as NULL after a character-typed bind (#300)

### DIFF
--- a/IscDbc/Sqlda.cpp
+++ b/IscDbc/Sqlda.cpp
@@ -684,7 +684,7 @@ void Sqlda::print()
 //
 int Sqlda::getColumnDisplaySize(int index)
 {
-	const SqlProperties *var = (SqldaDir == SQLDA_INPUT) ? orgVarSqlProperties(index) : Var(index);
+	const SqlProperties *var = describedSqlProperties(index);
 
 	switch (var->sqltype)
 	{
@@ -843,7 +843,7 @@ int Sqlda::getNumPrecRadix(int index)
 
 int Sqlda::getScale(int index)
 {
-	CAttrSqlVar *var = Var(index);
+	const SqlProperties *var = describedSqlProperties(index);
 
 	switch (var->sqltype)
 	{
@@ -862,20 +862,20 @@ bool Sqlda::isNullable(int index)
 
 int Sqlda::getColumnType(int index, int &realSqlType)
 {
-	return getSqlType ( Var(index), realSqlType );
+	return getSqlType ( describedSqlProperties(index), Var(index)->array, realSqlType );
 }
 
 const char* Sqlda::getColumnTypeName(int index)
 {
-	return getSqlTypeName ( Var(index) );
+	return getSqlTypeName ( describedSqlProperties(index) );
 }
 
 short Sqlda::getSubType(int index)
 {
-	return Var( index )->sqlsubtype;
+	return describedSqlProperties( index )->sqlsubtype;
 }
 
-int Sqlda::getSqlType(CAttrSqlVar *var, int &realSqlType)
+int Sqlda::getSqlType(const SqlProperties *var, const CAttrArray *array, int &realSqlType)
 {
 	switch (var->sqltype)
 	{
@@ -935,7 +935,7 @@ int Sqlda::getSqlType(CAttrSqlVar *var, int &realSqlType)
 		return (realSqlType = JDBC_DATE);
 
 	case SQL_ARRAY:
-		if ( var->array->arrOctetLength < MAX_VARCHAR_LENGTH )
+		if ( array->arrOctetLength < MAX_VARCHAR_LENGTH )
 			return (realSqlType = JDBC_VARCHAR);
 		return (realSqlType = JDBC_LONGVARCHAR);
 	}
@@ -943,7 +943,7 @@ int Sqlda::getSqlType(CAttrSqlVar *var, int &realSqlType)
 	return (realSqlType = 0);
 }
 
-const char* Sqlda::getSqlTypeName ( CAttrSqlVar *var )
+const char* Sqlda::getSqlTypeName ( const SqlProperties *var )
 {
 	switch (var->sqltype)
 	{

--- a/IscDbc/Sqlda.h
+++ b/IscDbc/Sqlda.h
@@ -178,8 +178,8 @@ public:
 	void setArray(CAttrSqlVar* var, Value* value, IscStatement* stmt);
 	void setValue(int slot, Value* value, IscStatement* stmt);
 	const char* getTableName(int index);
-	int getSqlType(CAttrSqlVar* var, int& realSqlType);
-	const char* getSqlTypeName(CAttrSqlVar* var);
+	int getSqlType(const SqlProperties* var, const CAttrArray* array, int& realSqlType);
+	const char* getSqlTypeName(const SqlProperties* var);
 	bool isNullable(int index);
 	int getScale(int index);
 	int getPrecision(int index);
@@ -207,6 +207,19 @@ public:
 	void clearSqlda();
 	CAttrSqlVar* Var(int index) { return &sqlvar.at(index - 1); }
 	const SqlProperties* orgVarSqlProperties(int index) { return &sqlvar.at(index - 1).orgSqlProperties; }
+
+	// Properties an index should be *described* with.
+	//
+	// An INPUT parameter is always described from the prepare-time snapshot: the
+	// conversion layer rewrites the live sqlvar to match whatever C type was last
+	// bound (OdbcConvert::setHeadSqlVar), so the live one tells us how the previous
+	// transfer was shaped, not what the statement was prepared with.  Describing
+	// from it makes a bind on an already-used parameter see that shape and keep it
+	// forever.  OUTPUT columns are never rewritten, so they use the live sqlvar.
+	const SqlProperties* describedSqlProperties(int index)
+	{
+		return (SqldaDir == SQLDA_INPUT) ? orgVarSqlProperties(index) : Var(index);
+	}
 
 	Sqlda(IscConnection* conn, e_sqlda_dir dir);
 	~Sqlda();

--- a/tests/test_param_conversions.cpp
+++ b/tests/test_param_conversions.cpp
@@ -87,6 +87,98 @@ protected:
         SQLCloseCursor(hStmt);
         return std::string((char*)buf);
     }
+
+    // Read a single column back as a string ("NULL" for a null value).
+    std::string readBack(const char* colName, int id) {
+        char selectSql[256];
+        snprintf(selectSql, sizeof(selectSql),
+            "SELECT %s FROM ODBC_TEST_PCONV WHERE ID = %d", colName, id);
+        SQLRETURN ret = SQLExecDirect(hStmt, (SQLCHAR*)selectSql, SQL_NTS);
+        if (!SQL_SUCCEEDED(ret)) return "<select-error>";
+
+        SQLCHAR buf[256] = {};
+        SQLLEN ind = 0;
+        SQLBindCol(hStmt, 1, SQL_C_CHAR, buf, sizeof(buf), &ind);
+        ret = SQLFetch(hStmt);
+        if (!SQL_SUCCEEDED(ret)) return "<fetch-error>";
+        SQLCloseCursor(hStmt);
+        SQLFreeStmt(hStmt, SQL_UNBIND);
+        return ind == SQL_NULL_DATA ? "NULL" : std::string((char*)buf);
+    }
+
+    // Send one NULL row and one value row through a single prepared statement,
+    // binding the NULL with SQL_C_DEFAULT (which resolves to SQL_C_CHAR for
+    // SQL_NUMERIC, SQL_DECIMAL and SQL_BIGINT) and the value with SQL_C_SLONG.
+    // Returns the value row read back.
+    std::string nullThenValueRebind(const char* colName, bool resetParams) {
+        const int nullId = nextId_++;
+        const int valueId = nextId_++;
+
+        char sql[256];
+        snprintf(sql, sizeof(sql),
+            "UPDATE OR INSERT INTO ODBC_TEST_PCONV (ID, %s) VALUES (?, ?)", colName);
+        SQLRETURN ret = SQLPrepare(hStmt, (SQLCHAR*)sql, SQL_NTS);
+        EXPECT_TRUE(SQL_SUCCEEDED(ret))
+            << "SQLPrepare failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        if (!SQL_SUCCEEDED(ret)) return "<prepare-error>";
+
+        SQLSMALLINT paramType = 0, decimals = 0, nullable = 0;
+        SQLULEN paramSize = 0;
+        ret = SQLDescribeParam(hStmt, 2, &paramType, &paramSize, &decimals, &nullable);
+        EXPECT_TRUE(SQL_SUCCEEDED(ret))
+            << "SQLDescribeParam failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        if (!SQL_SUCCEEDED(ret)) return "<describe-error>";
+
+        SQLINTEGER idVal = nullId;
+        SQLLEN idInd = sizeof(idVal);
+        SQLINTEGER value = 0;
+        SQLLEN valueInd = SQL_NULL_DATA;
+
+        auto bindId = [&]() {
+            return SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+                SQL_C_SLONG, SQL_INTEGER, 0, 0, &idVal, sizeof(idVal), &idInd);
+        };
+
+        ret = bindId();
+        EXPECT_TRUE(SQL_SUCCEEDED(ret)) << "bind of ID failed";
+
+        // The NULL row: no C type of its own, no data pointer - only the indicator.
+        ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT,
+            SQL_C_DEFAULT, paramType, paramSize, decimals, NULL, 0, &valueInd);
+        EXPECT_TRUE(SQL_SUCCEEDED(ret))
+            << "bind of NULL failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        ret = SQLExecute(hStmt);
+        EXPECT_TRUE(SQL_SUCCEEDED(ret))
+            << "execute of the NULL row failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        // The value row, rebound with a numeric C type.
+        idVal = valueId;
+        value = 60;
+        valueInd = sizeof(value);
+
+        SQLFreeStmt(hStmt, SQL_CLOSE);
+        if (resetParams) {
+            SQLFreeStmt(hStmt, SQL_RESET_PARAMS);
+            ret = bindId();
+            EXPECT_TRUE(SQL_SUCCEEDED(ret)) << "rebind of ID failed";
+        }
+
+        ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT,
+            SQL_C_SLONG, paramType, paramSize, decimals, &value, sizeof(value), &valueInd);
+        EXPECT_TRUE(SQL_SUCCEEDED(ret))
+            << "rebind of the value failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        ret = SQLExecute(hStmt);
+        EXPECT_TRUE(SQL_SUCCEEDED(ret))
+            << "execute of the value row failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        Commit();
+        ReallocStmt();
+
+        EXPECT_EQ(readBack(colName, nullId), "NULL") << "the NULL row did not stay NULL";
+        return readBack(colName, valueId);
+    }
 };
 
 // ===== String → Integer =====
@@ -275,6 +367,84 @@ TEST_F(ParamConversionsTest, NumericAsCharParam) {
     std::string result = insertAndReadBack("VAL_NUMERIC",
         SQL_C_CHAR, SQL_NUMERIC, val, 0, &ind);
     EXPECT_NEAR(atof(result.c_str()), 1234.5678, 0.001);
+}
+
+// ===== A character-typed bind must not retype the parameter =====
+//
+// SQL_C_DEFAULT resolves to SQL_C_CHAR for SQL_NUMERIC, SQL_DECIMAL and SQL_BIGINT,
+// so an application that binds its NULLs with SQL_C_DEFAULT and its values with the
+// value's own C type sends a character transfer first.  That transfer used to retype
+// the parameter for the rest of the statement's life: every later bind was described
+// as CHAR, and rows following the NULL reached the server as NULL with SQL_SUCCESS.
+// SQL_INTEGER / SQL_SMALLINT / SQL_DOUBLE were unaffected only because their
+// SQL_C_DEFAULT never resolves to a character C type.
+
+TEST_F(ParamConversionsTest, NullAsDefaultThenBigintRebind) {
+    SKIP_ON_FIREBIRD6();
+    EXPECT_EQ(atoi(nullThenValueRebind("VAL_BIGINT", false).c_str()), 60);
+}
+
+TEST_F(ParamConversionsTest, NullAsDefaultThenNumericRebind) {
+    SKIP_ON_FIREBIRD6();
+    EXPECT_NEAR(atof(nullThenValueRebind("VAL_NUMERIC", false).c_str()), 60.0, 0.001);
+}
+
+TEST_F(ParamConversionsTest, NullAsDefaultThenIntegerRebind) {
+    SKIP_ON_FIREBIRD6();
+    EXPECT_EQ(atoi(nullThenValueRebind("VAL_INT", false).c_str()), 60);
+}
+
+// SQLFreeStmt(SQL_RESET_PARAMS) does not help: the state that was lost lived in the
+// parameter itself, not in the descriptors the reset clears.
+TEST_F(ParamConversionsTest, NullAsDefaultThenBigintRebindAfterResetParams) {
+    SKIP_ON_FIREBIRD6();
+    EXPECT_EQ(atoi(nullThenValueRebind("VAL_BIGINT", true).c_str()), 60);
+}
+
+// The same retyping was visible directly: SQLDescribeParam reported CHAR for a
+// BIGINT parameter once a character transfer had gone through it.
+TEST_F(ParamConversionsTest, DescribeParamStableAfterCharBind) {
+    SKIP_ON_FIREBIRD6();
+
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"UPDATE OR INSERT INTO ODBC_TEST_PCONV (ID, VAL_BIGINT) VALUES (?, ?)",
+        SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret))
+        << "SQLPrepare failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    SQLSMALLINT typeBefore = 0, decimals = 0, nullable = 0;
+    SQLULEN paramSize = 0;
+    ret = SQLDescribeParam(hStmt, 2, &typeBefore, &paramSize, &decimals, &nullable);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret))
+        << "SQLDescribeParam failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(typeBefore, SQL_BIGINT);
+
+    SQLINTEGER idVal = nextId_++;
+    SQLLEN idInd = sizeof(idVal);
+    SQLLEN valueInd = SQL_NULL_DATA;
+
+    ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT,
+        SQL_C_SLONG, SQL_INTEGER, 0, 0, &idVal, sizeof(idVal), &idInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << "bind of ID failed";
+
+    ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT,
+        SQL_C_CHAR, SQL_BIGINT, paramSize, decimals, NULL, 0, &valueInd);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret))
+        << "bind of NULL failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    ret = SQLExecute(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret))
+        << "SQLExecute failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    SQLSMALLINT typeAfter = 0;
+    ret = SQLDescribeParam(hStmt, 2, &typeAfter, &paramSize, &decimals, &nullable);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret))
+        << "second SQLDescribeParam failed: " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(typeAfter, typeBefore)
+        << "the parameter was redescribed after a character-typed bind";
+
+    Commit();
+    ReallocStmt();
 }
 
 // ===== Already-covered round-trip tests from test_data_types.cpp =====


### PR DESCRIPTION
Fixes #300.

## The problem

A parameter's sqlvar is rewritten on every bind to match the C type being transferred (`OdbcConvert::setHeadSqlVar`, called at the top of `getAdressFunction`), but the driver described the parameter from that same live sqlvar. That closes a loop:

| execute | describe reads sqlvar | converter chosen | `setHeadSqlVar` writes sqlvar |
|---|---|---|---|
| NULL bound `SQL_C_DEFAULT` | `SQL_INT64` (correct) | `transferStringToAllowedType` | `SQL_TEXT` |
| value bound `SQL_C_SLONG` | `SQL_TEXT` | `convLongToString` | `SQL_TEXT` again |

`SQL_C_DEFAULT` resolves to `SQL_C_CHAR` for `SQL_NUMERIC`, `SQL_DECIMAL` and `SQL_BIGINT`, so an application that binds its NULLs with `SQL_C_DEFAULT` and its values with the value's own C type retyped the parameter on its first NULL and never got it back. Every later row on that parameter was written as text into a numeric column, and — because the sqlvar's null flag was still set from the NULL row — reached the server as NULL, with `SQL_SUCCESS` and a correct row count. `SQLFreeStmt(SQL_RESET_PARAMS)` did not help: the state was in the sqlvar, not in the descriptors. `SQLDescribeParam` reported `SQL_CHAR` for the parameter as well.

`SQL_INTEGER`, `SQL_SMALLINT` and `SQL_DOUBLE` escaped only because their `SQL_C_DEFAULT` never resolves to a character C type.

## The fix

Describe INPUT parameters from the prepare-time snapshot (`orgSqlProperties`) rather than the live sqlvar, which is what `getColumnDisplaySize()` already did. A bind then always sees the type the statement was prepared with, and `setHeadSqlVar` shapes the sqlvar back to it. OUTPUT columns keep reading the live sqlvar, which is never rewritten.

`getPrecision` is deliberately untouched here — this fix does not need it, and #292 already changes it.

## Tests

Five tests in `tests/test_param_conversions.cpp`. Four fail on master and pass with the fix; `NullAsDefaultThenIntegerRebind` passes both ways and is the control that documents why `SQL_INTEGER` was unaffected.

Verified on Windows against Firebird 5.0.3 with the Microsoft driver manager, using the reproduction matrix from the issue (24 cells over `NUMERIC(9,3)`, `DECIMAL(18,2)`, `BIGINT`, `INTEGER`, `SMALLINT`, `DOUBLE PRECISION`): 6 lost cells on master, 0 with this branch. The full suite passes in all three charset configurations.

## Still open

Two neighbouring defects on the numeric-to-string parameter path are **not** addressed here, and both are visible with a single binding whose indicator toggles NULL then value on a `VARCHAR`/`CHAR` parameter:

- `ODBCCONVERT_CHECKNULL` never clears the target null flag on the not-null path, unlike its two sibling macros. For a sqlda target that flag survives between executes, so a value after a NULL is sent as NULL.
- Behind it, the truncation from [duckdb/odbc-scanner#161](https://github.com/duckdb/odbc-scanner/issues/161): with that flag cleared, master writes `6` for `60`.

They belong with #292, which owns that code path; #292 as it stands fixes neither. Both now sit on that PR, with tests.

