### PR TITLE
Fix SQLPrepare discarding SQL_ATTR_ROWS_FETCHED_PTR and SQL_ATTR_ROW_STATUS_PTR (#301)

### DIFF
--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -85,9 +85,7 @@ void OdbcDesc::setDefaultImplDesc (StatementMetaData * ptMetaDataOut, StatementM
 
 		headAllocType = SQL_DESC_ALLOC_AUTO;
 		headArraySize = 1;
-		headArrayStatusPtr = (SQLUSMALLINT*)NULL;
 		headBindOffsetPtr = (SQLLEN*)NULL;
-		headRowsProcessedPtr = (SQLULEN*)NULL;
 		headCount = 0;
 
 		if(	metaDataOut == NULL )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(firebird_odbc_tests
     test_param_conversions.cpp
     test_prepare.cpp
     test_cursors.cpp
+    test_block_cursor.cpp
     test_cursor_commit.cpp
     test_cursor_name.cpp
     test_data_at_execution.cpp

--- a/tests/test_block_cursor.cpp
+++ b/tests/test_block_cursor.cpp
@@ -1,0 +1,126 @@
+// tests/test_block_cursor.cpp — Block cursor (SQL_ATTR_ROW_ARRAY_SIZE > 1) tests
+//
+// Covers the IRD header fields an application reads back after a rowset
+// fetch: SQL_ATTR_ROWS_FETCHED_PTR and SQL_ATTR_ROW_STATUS_PTR. Statement
+// attributes persist until the statement is freed or the attribute is set
+// again; in particular SQLPrepare / SQLExecDirect must not discard them.
+
+#include "test_helpers.h"
+
+class BlockCursorTest : public OdbcConnectedTest {
+protected:
+    static constexpr SQLULEN kArraySize = 4;
+
+    // Six rows, no table and no parameters needed.
+    static const char* SixRowsSql() {
+        return "SELECT 1 FROM rdb$database UNION ALL SELECT 2 FROM rdb$database"
+               " UNION ALL SELECT 3 FROM rdb$database UNION ALL SELECT 4 FROM rdb$database"
+               " UNION ALL SELECT 5 FROM rdb$database UNION ALL SELECT 6 FROM rdb$database";
+    }
+
+    SQLULEN rowsFetched_ = 777;
+    SQLUSMALLINT rowStatus_[kArraySize] = {9, 9, 9, 9};
+    SQLINTEGER values_[kArraySize] = {-1, -1, -1, -1};
+    SQLLEN indicators_[kArraySize] = {0, 0, 0, 0};
+
+    void SetRowsetAttrs() {
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ATTR_ROW_ARRAY_SIZE,
+                                                 (SQLPOINTER)kArraySize, 0)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ATTR_ROWS_FETCHED_PTR,
+                                                 &rowsFetched_, 0)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ATTR_ROW_STATUS_PTR,
+                                                 rowStatus_, 0)));
+    }
+
+    void BindColumn() {
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLBindCol(hStmt, 1, SQL_C_SLONG, values_, 0, indicators_)));
+    }
+
+    // Poison every output so an unwritten value is visible.
+    void ResetOutputs() {
+        rowsFetched_ = 777;
+        for (SQLULEN i = 0; i < kArraySize; i++) {
+            rowStatus_[i] = 9;
+            values_[i] = -1;
+        }
+    }
+
+    // Expects the six rows to arrive as a full rowset of 4 followed by a
+    // partial rowset of 2, with the counter and status array written both times.
+    void FetchAndVerifySixRows() {
+        ResetOutputs();
+        SQLRETURN ret = SQLFetch(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        EXPECT_EQ(rowsFetched_, 4u) << "first rowset: SQL_ATTR_ROWS_FETCHED_PTR not written";
+        for (SQLULEN i = 0; i < kArraySize; i++) {
+            EXPECT_EQ(rowStatus_[i], SQL_ROW_SUCCESS) << "row status " << i;
+            EXPECT_EQ(values_[i], (SQLINTEGER)(i + 1)) << "value " << i;
+        }
+
+        ResetOutputs();
+        ret = SQLFetch(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        EXPECT_EQ(rowsFetched_, 2u) << "last rowset: SQL_ATTR_ROWS_FETCHED_PTR not written";
+        EXPECT_EQ(rowStatus_[0], SQL_ROW_SUCCESS);
+        EXPECT_EQ(rowStatus_[1], SQL_ROW_SUCCESS);
+        EXPECT_EQ(rowStatus_[2], SQL_ROW_NOROW);
+        EXPECT_EQ(rowStatus_[3], SQL_ROW_NOROW);
+        EXPECT_EQ(values_[0], 5);
+        EXPECT_EQ(values_[1], 6);
+
+        ret = SQLFetch(hStmt);
+        EXPECT_EQ(ret, SQL_NO_DATA);
+    }
+};
+
+// Attributes set before SQLPrepare must survive it.
+TEST_F(BlockCursorTest, RowsFetchedPtrSetBeforePrepare) {
+    SetRowsetAttrs();
+
+    SQLRETURN ret = SQLPrepare(hStmt, (SQLCHAR*)SixRowsSql(), SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    // The attribute must still be readable after the prepare.
+    SQLPOINTER ptr = nullptr;
+    ret = SQLGetStmtAttr(hStmt, SQL_ATTR_ROW_STATUS_PTR, &ptr, 0, nullptr);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(ptr, (SQLPOINTER)rowStatus_) << "SQLPrepare discarded SQL_ATTR_ROW_STATUS_PTR";
+
+    ret = SQLExecute(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    BindColumn();
+    FetchAndVerifySixRows();
+}
+
+// Attributes set before SQLExecDirect must survive it.
+TEST_F(BlockCursorTest, RowsFetchedPtrSetBeforeExecDirect) {
+    SetRowsetAttrs();
+    ExecDirect(SixRowsSql());
+    BindColumn();
+    FetchAndVerifySixRows();
+}
+
+// Control: attributes set between SQLPrepare and SQLExecute already worked.
+TEST_F(BlockCursorTest, RowsFetchedPtrSetAfterPrepare) {
+    SQLRETURN ret = SQLPrepare(hStmt, (SQLCHAR*)SixRowsSql(), SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SetRowsetAttrs();
+    ret = SQLExecute(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    BindColumn();
+    FetchAndVerifySixRows();
+}
+
+// A statement handle reused for a second statement keeps the attributes
+// (the pattern of an application that configures a handle once).
+TEST_F(BlockCursorTest, RowsFetchedPtrSurvivesHandleReuse) {
+    SetRowsetAttrs();
+    ExecDirect(SixRowsSql());
+    BindColumn();
+    FetchAndVerifySixRows();
+
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLFreeStmt(hStmt, SQL_CLOSE)));
+
+    ExecDirect(SixRowsSql());
+    FetchAndVerifySixRows();
+}


### PR DESCRIPTION
Fixes #301.

## The problem

`OdbcDesc::setDefaultImplDesc` rebuilds the implementation row descriptor on every prepare, and its IRD branch also reset `SQL_DESC_ROWS_PROCESSED_PTR` and `SQL_DESC_ARRAY_STATUS_PTR` to NULL. `sqlPrepare` calls it (so `SQLExecDirect` too), as does `setResultSet` for catalog functions. An application that set `SQL_ATTR_ROWS_FETCHED_PTR` / `SQL_ATTR_ROW_STATUS_PTR` before `SQLPrepare` or `SQLExecDirect` — the usual order — never had them written by `SQLFetch`: the rows-fetched counter kept whatever it held and the status array stayed untouched, on every fetch including the last partial one. Set after the prepare, both worked. The IPD branch of the same function never resets its own counterparts, which is why `SQL_ATTR_PARAMS_PROCESSED_PTR` survives a prepare and the row-side pointers did not.

Statement attributes persist until the statement is freed or the attribute is set again; `SQLPrepare` is not supposed to clear them. The reset dates from 2004/2008, so every released version is affected.

## The fix

Drop the two pointer resets from the IRD branch of `setDefaultImplDesc`. The other header fields reset there (`headAllocType`, `headArraySize`, `headBindOffsetPtr`) are ARD-only fields in ODBC terms and nothing reads them from the IRD, so they are left as they were.

## Tests

`tests/test_block_cursor.cpp`: four cases over a six-row `UNION ALL` with `SQL_ATTR_ROW_ARRAY_SIZE = 4`, each asserting the counter (4, then 2), the status array (`SQL_ROW_SUCCESS` / `SQL_ROW_NOROW`) and the bound values on both rowsets, then `SQL_NO_DATA`.

- `RowsFetchedPtrSetBeforePrepare` — also asserts that `SQLGetStmtAttr(SQL_ATTR_ROW_STATUS_PTR)` still returns the pointer after `SQLPrepare`. Fails on master.
- `RowsFetchedPtrSetBeforeExecDirect` — fails on master.
- `RowsFetchedPtrSurvivesHandleReuse` — attributes kept across `SQLFreeStmt(SQL_CLOSE)` and a second `SQLExecDirect` on the same handle. Fails on master.
- `RowsFetchedPtrSetAfterPrepare` — control, passes both ways.

Verified on Windows x64 against Firebird 5.0.3 with the Microsoft driver manager. The reporter's program reproduces the output from the issue verbatim on master and prints the correct counters with this branch for all five orderings (before / between / after `SQLPrepare` + `SQLExecute`; before / after `SQLExecDirect`). Full suite: 392 ran, 227 passed, 165 skipped, 0 failed.

## Still open

- `SQLGetStmtAttr(SQL_ATTR_ROWS_FETCHED_PTR)` returns `HYC00`: `sqlGetStmtAttr` has no case for it (nor for `SQL_ATTR_PARAMS_PROCESSED_PTR`, `SQL_ATTR_PARAM_STATUS_PTR`, `SQL_ATTR_PARAM_OPERATION_PTR`, `SQL_ATTR_ROW_OPERATION_PTR` and the two `*_BIND_OFFSET_PTR` attributes), so the `default:` branch answers. Setting them works, and once the statement is prepared the same pointers come back through `SQLGetDescField` on the IRD (`SQL_DESC_ROWS_PROCESSED_PTR`, `SQL_DESC_ARRAY_STATUS_PTR`; before prepare the IRD answers `HY091`). Only the statement-attribute read-back is missing. Separate change; the test above reads back `SQL_ATTR_ROW_STATUS_PTR`, which does have a case.
- The same two lines exist in the v5 RFC (#283), whose block-fetch test hides the symptom behind an `if (rowsFetched > 0)`. Both will be corrected there on its next rebase.
