### PR TITLE
Return the settable pointer attributes and SQL_ATTR_CURSOR_SCROLLABLE from SQLGetStmtAttr

### DIFF
--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -2622,6 +2622,46 @@ SQLRETURN OdbcStatement::sqlGetStmtAttr(int attribute, SQLPOINTER ptr, int buffe
 			TRACE02(SQL_ATTR_ROW_STATUS_PTR,value);
 			break;
 
+		case SQL_ATTR_ROWS_FETCHED_PTR:
+			value = (intptr_t) implementationRowDescriptor->headRowsProcessedPtr;
+			TRACE02(SQL_ATTR_ROWS_FETCHED_PTR,value);
+			break;
+
+		case SQL_ATTR_ROW_BIND_OFFSET_PTR:
+			value = (intptr_t) applicationRowDescriptor->headBindOffsetPtr;
+			TRACE02(SQL_ATTR_ROW_BIND_OFFSET_PTR,value);
+			break;
+
+		case SQL_ATTR_ROW_OPERATION_PTR:
+			value = (intptr_t) applicationRowDescriptor->headArrayStatusPtr;
+			TRACE02(SQL_ATTR_ROW_OPERATION_PTR,value);
+			break;
+
+		case SQL_ATTR_PARAMS_PROCESSED_PTR:
+			value = (intptr_t) implementationParamDescriptor->headRowsProcessedPtr;
+			TRACE02(SQL_ATTR_PARAMS_PROCESSED_PTR,value);
+			break;
+
+		case SQL_ATTR_PARAM_BIND_OFFSET_PTR:
+			value = (intptr_t) applicationParamDescriptor->headBindOffsetPtr;
+			TRACE02(SQL_ATTR_PARAM_BIND_OFFSET_PTR,value);
+			break;
+
+		case SQL_ATTR_PARAM_OPERATION_PTR:
+			value = (intptr_t) applicationParamDescriptor->headArrayStatusPtr;
+			TRACE02(SQL_ATTR_PARAM_OPERATION_PTR,value);
+			break;
+
+		case SQL_ATTR_PARAM_STATUS_PTR:
+			value = (intptr_t) implementationParamDescriptor->headArrayStatusPtr;
+			TRACE02(SQL_ATTR_PARAM_STATUS_PTR,value);
+			break;
+
+		case SQL_ATTR_CURSOR_SCROLLABLE:
+			value = cursorScrollable;
+			TRACE02(SQL_ATTR_CURSOR_SCROLLABLE,value);
+			break;
+
 		case SQL_ATTR_USE_BOOKMARKS:
 			value = useBookmarks;
 			TRACE02(SQL_ATTR_USE_BOOKMARKS,value);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(firebird_odbc_tests
     test_prepare.cpp
     test_cursors.cpp
     test_cursor_commit.cpp
+    test_stmt_attrs.cpp
     test_cursor_name.cpp
     test_data_at_execution.cpp
     test_array_binding.cpp

--- a/tests/test_stmt_attrs.cpp
+++ b/tests/test_stmt_attrs.cpp
@@ -1,0 +1,100 @@
+// tests/test_stmt_attrs.cpp — Statement attribute round trips
+//
+// Every statement attribute the driver accepts in SQLSetStmtAttr must come
+// back unchanged from SQLGetStmtAttr. The pointer attributes live in the
+// descriptor headers and are only dereferenced by a later fetch or execute,
+// so any address will do here; nothing is fetched or executed.
+
+#include "test_helpers.h"
+
+class StmtAttrTest : public OdbcConnectedTest {
+protected:
+    // Sets `attr` to a pointer, reads it back, then sets it to NULL and
+    // reads that back as well.
+    void ExpectPointerRoundTrip(SQLINTEGER attr, const char* name) {
+        SQLULEN sink[4] = {};
+        SQLPOINTER in = sink;
+
+        SQLRETURN ret = SQLSetStmtAttr(hStmt, attr, in, 0);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << name << ": set failed: "
+                                        << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        SQLPOINTER out = nullptr;
+        ret = SQLGetStmtAttr(hStmt, attr, &out, 0, nullptr);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << name << ": get failed: "
+                                        << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        EXPECT_EQ(out, in) << name;
+
+        ret = SQLSetStmtAttr(hStmt, attr, nullptr, 0);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << name << ": set NULL failed: "
+                                        << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        out = in;
+        ret = SQLGetStmtAttr(hStmt, attr, &out, 0, nullptr);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << name << ": get after NULL failed: "
+                                        << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        EXPECT_EQ(out, nullptr) << name;
+    }
+};
+
+TEST_F(StmtAttrTest, RowsFetchedPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_ROWS_FETCHED_PTR, "SQL_ATTR_ROWS_FETCHED_PTR");
+}
+
+TEST_F(StmtAttrTest, RowBindOffsetPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_ROW_BIND_OFFSET_PTR, "SQL_ATTR_ROW_BIND_OFFSET_PTR");
+}
+
+TEST_F(StmtAttrTest, RowOperationPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_ROW_OPERATION_PTR, "SQL_ATTR_ROW_OPERATION_PTR");
+}
+
+TEST_F(StmtAttrTest, ParamsProcessedPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_PARAMS_PROCESSED_PTR, "SQL_ATTR_PARAMS_PROCESSED_PTR");
+}
+
+TEST_F(StmtAttrTest, ParamBindOffsetPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_PARAM_BIND_OFFSET_PTR, "SQL_ATTR_PARAM_BIND_OFFSET_PTR");
+}
+
+TEST_F(StmtAttrTest, ParamOperationPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_PARAM_OPERATION_PTR, "SQL_ATTR_PARAM_OPERATION_PTR");
+}
+
+TEST_F(StmtAttrTest, ParamStatusPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_PARAM_STATUS_PTR, "SQL_ATTR_PARAM_STATUS_PTR");
+}
+
+// Control: the one pointer attribute that could already be read back.
+TEST_F(StmtAttrTest, RowStatusPtr) {
+    ExpectPointerRoundTrip(SQL_ATTR_ROW_STATUS_PTR, "SQL_ATTR_ROW_STATUS_PTR");
+}
+
+TEST_F(StmtAttrTest, CursorScrollable) {
+    SQLULEN value = 999;
+    SQLRETURN ret = SQLGetStmtAttr(hStmt, SQL_ATTR_CURSOR_SCROLLABLE, &value, 0, nullptr);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(value, (SQLULEN)SQL_NONSCROLLABLE) << "default";
+
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_CURSOR_SCROLLABLE, (SQLPOINTER)SQL_SCROLLABLE, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    value = 999;
+    ret = SQLGetStmtAttr(hStmt, SQL_ATTR_CURSOR_SCROLLABLE, &value, 0, nullptr);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(value, (SQLULEN)SQL_SCROLLABLE);
+
+    // Asking for a scrollable cursor moves the cursor type off forward-only.
+    value = 999;
+    ret = SQLGetStmtAttr(hStmt, SQL_ATTR_CURSOR_TYPE, &value, 0, nullptr);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_NE(value, (SQLULEN)SQL_CURSOR_FORWARD_ONLY);
+
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_CURSOR_SCROLLABLE, (SQLPOINTER)SQL_NONSCROLLABLE, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    value = 999;
+    ret = SQLGetStmtAttr(hStmt, SQL_ATTR_CURSOR_SCROLLABLE, &value, 0, nullptr);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(value, (SQLULEN)SQL_NONSCROLLABLE);
+}


### PR DESCRIPTION
Every statement attribute that `SQLSetStmtAttr` accepts should come back from `SQLGetStmtAttr`. Eight did not: the getter's `switch` had no case for them, so they fell through to `default:` and returned `HYC00` "Optional feature not implemented", although the setter had stored the value and the driver was using it.

| attribute | stored in |
|---|---|
| `SQL_ATTR_ROWS_FETCHED_PTR` | IRD rows-processed pointer |
| `SQL_ATTR_ROW_BIND_OFFSET_PTR` | ARD bind-offset pointer |
| `SQL_ATTR_ROW_OPERATION_PTR` | ARD array-status pointer |
| `SQL_ATTR_PARAMS_PROCESSED_PTR` | IPD rows-processed pointer |
| `SQL_ATTR_PARAM_BIND_OFFSET_PTR` | APD bind-offset pointer |
| `SQL_ATTR_PARAM_OPERATION_PTR` | APD array-status pointer |
| `SQL_ATTR_PARAM_STATUS_PTR` | IPD array-status pointer |
| `SQL_ATTR_CURSOR_SCROLLABLE` | `cursorScrollable` |

Noticed while working on #303: an application cannot even check which rows-fetched pointer it set. Generic ODBC consumers that save and restore statement attributes hit the error as well.

## The fix

One `case` per attribute in `OdbcStatement::sqlGetStmtAttr`, each mirroring the existing `SQL_ATTR_ROW_STATUS_PTR` case: read the same descriptor header field the setter writes. `SQL_ATTR_CURSOR_SCROLLABLE` returns what the setter stored (default `SQL_NONSCROLLABLE`).

## Tests

`tests/test_stmt_attrs.cpp`: one set-then-get round trip per pointer attribute (a pointer, then NULL), `SQL_ATTR_ROW_STATUS_PTR` as the control that already passed, and a `SQL_ATTR_CURSOR_SCROLLABLE` case checking the default, both values, and that `SQL_SCROLLABLE` moves `SQL_ATTR_CURSOR_TYPE` off forward-only. Eight of the nine fail on master; all pass with this branch.

Verified on Windows x64 against Firebird 5.0.3 with the Microsoft driver manager. Full suite: 397 ran, 232 passed, 165 skipped, 0 failed.

Independent of #303: the tests set and read without a prepare in between.

## Still open

`SQL_ATTR_KEYSET_SIZE` is also settable without a getter, but the setter stores it in the ARD array size, which is not what that attribute means, so a getter would only document the wrong behaviour. Left alone.
