### PR TITLE
Fix column-wise parameter arrays reading element 0 for fixed-length C types (#299)

### DIFF
--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -1566,6 +1566,9 @@ int OdbcDesc::getConciseSize(int type, int length)
 	case SQL_C_UBIGINT:
 		return 8;
 
+	case SQL_C_GUID:
+		return sizeof(SQLGUID);
+
 	case SQL_DECIMAL:
 	case SQL_C_NUMERIC:
 		return sizeof(tagSQL_NUMERIC_STRUCT);

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -1987,7 +1987,11 @@ SQLRETURN OdbcStatement::sqlExecute()
 		enFetch = NoneFetch;
 		releaseResultSet();
 		parameterNeedData = 0;
-		retcode = (this->*execute)();
+		if ( statement->isActiveModify() && applicationParamDescriptor->headArraySize > 1
+			&& execute != &OdbcStatement::executeStatementParamArray )
+			retcode = executeStatementParamArray();
+		else
+			retcode = (this->*execute)();
 	}
 	catch (const SQLException &ex)
 	{
@@ -2015,7 +2019,11 @@ SQLRETURN OdbcStatement::sqlExecDirect(SQLCHAR * sql, int sqlLength)
 	{
 		enFetch = NoneFetch;
 		parameterNeedData = 0;
-		retcode = (this->*execute)();
+		if ( statement->isActiveModify() && applicationParamDescriptor->headArraySize > 1
+			&& execute != &OdbcStatement::executeStatementParamArray )
+			retcode = executeStatementParamArray();
+		else
+			retcode = (this->*execute)();
 	}
 	catch (const SQLException &ex)
 	{

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -2744,6 +2744,18 @@ void OdbcStatement::bindInputOutputParam(int param, DescRecord * recordApp)
 
 		recordApp->fnConv = convert->getAdressFunction( recordApp, record );
 
+		switch ( recordApp->conciseType )
+		{
+		case SQL_C_CHAR:
+		case SQL_C_WCHAR:
+		case SQL_C_BINARY:
+			break;
+
+		default:
+			if ( !recordApp->sizeColumnExtendedFetch )
+				recordApp->sizeColumnExtendedFetch = ipd->getConciseSize( recordApp->conciseType, recordApp->length );
+		}
+
 //		if ( convert->isIdentity() )
 			addBindParam ( param, record, recordApp );
 	}

--- a/tests/test_array_binding.cpp
+++ b/tests/test_array_binding.cpp
@@ -68,7 +68,7 @@ protected:
 //    (ported from psqlodbc arraybinding-test.c test 1)
 // ============================================================================
 TEST_F(ArrayBindingTest, ColumnWiseInsert) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int ARRAY_SIZE = 100;
     SQLRETURN ret;
 
@@ -134,7 +134,7 @@ TEST_F(ArrayBindingTest, ColumnWiseInsert) {
 // 2. Column-wise binding — using SQLPrepare + SQLExecute
 // ============================================================================
 TEST_F(ArrayBindingTest, ColumnWisePrepareExecute) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int ARRAY_SIZE = 10;
     SQLRETURN ret;
 
@@ -257,7 +257,7 @@ TEST_F(ArrayBindingTest, RowWiseInsert) {
 // 4. Column-wise binding with NULL values
 // ============================================================================
 TEST_F(ArrayBindingTest, ColumnWiseWithNulls) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int ARRAY_SIZE = 5;
     SQLRETURN ret;
 
@@ -316,7 +316,7 @@ TEST_F(ArrayBindingTest, ColumnWiseWithNulls) {
 // 5. SQL_ATTR_PARAM_OPERATION_PTR — skip individual rows
 // ============================================================================
 TEST_F(ArrayBindingTest, ParamOperationPtrSkipRows) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    GTEST_SKIP() << "Vanilla driver does not properly handle SQL_ATTR_PARAM_OPERATION_PTR";
     const int ARRAY_SIZE = 5;
     SQLRETURN ret;
 
@@ -384,7 +384,7 @@ TEST_F(ArrayBindingTest, ParamOperationPtrSkipRows) {
 // 6. Large array — column-wise (like psqlodbc's 10000-row test)
 // ============================================================================
 TEST_F(ArrayBindingTest, LargeColumnWiseArray) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int ARRAY_SIZE = 1000;
     SQLRETURN ret;
 
@@ -442,7 +442,7 @@ TEST_F(ArrayBindingTest, LargeColumnWiseArray) {
 //    (from psqlodbc params-batch-exec-test.c)
 // ============================================================================
 TEST_F(ArrayBindingTest, ReExecuteWithDifferentData) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int BATCH_SIZE = 5;
     SQLRETURN ret;
 
@@ -516,7 +516,7 @@ TEST_F(ArrayBindingTest, ReExecuteWithDifferentData) {
 //     SQLSetStmtAttr survive SQLFreeStmt")
 // ============================================================================
 TEST_F(ArrayBindingTest, NewHandleAfterArrayExec) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int ARRAY_SIZE = 3;
     SQLRETURN ret;
 
@@ -658,7 +658,7 @@ TEST_F(ArrayBindingTest, RowWiseMultipleTypes) {
 // 10. Column-wise binding with UPDATE statement
 // ============================================================================
 TEST_F(ArrayBindingTest, ColumnWiseUpdate) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     // Insert some initial data
     {
         SQLHSTMT hStmt2 = SQL_NULL_HSTMT;
@@ -717,7 +717,7 @@ TEST_F(ArrayBindingTest, ColumnWiseUpdate) {
 // 11. Column-wise binding with DELETE statement
 // ============================================================================
 TEST_F(ArrayBindingTest, ColumnWiseDelete) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     // Insert initial data
     {
         SQLHSTMT hStmt2 = SQL_NULL_HSTMT;
@@ -828,7 +828,7 @@ TEST_F(ArrayBindingTest, GetInfoParamArraySelects) {
 // 15. Column-wise binding with integer-only (no strings)
 // ============================================================================
 TEST_F(ArrayBindingTest, ColumnWiseIntegerOnly) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     // Recreate table with integer-only columns
     ExecIgnoreError("DROP TABLE ARRAY_BIND_TEST");
     Commit();
@@ -959,7 +959,7 @@ TEST_F(ArrayBindingTest, RowWiseWithOperationPtr) {
 // 17. Without status/processed pointers (optional per spec)
 // ============================================================================
 TEST_F(ArrayBindingTest, WithoutStatusPointers) {
-    GTEST_SKIP() << "Crashes on vanilla master: sizeof(SQLINTEGER) vs sizeof(SQLLEN) bug in OdbcStatement.cpp line 2891";
+    SKIP_ON_FIREBIRD6();
     const int ARRAY_SIZE = 3;
     SQLRETURN ret;
 
@@ -986,4 +986,166 @@ TEST_F(ArrayBindingTest, WithoutStatusPointers) {
 
     Commit();
     EXPECT_EQ(CountRows(), ARRAY_SIZE);
+}
+
+// ============================================================================
+// 18. Column-wise binding, fixed-length C types with BufferLength = 0 (#299)
+//     The ODBC specification ignores BufferLength for fixed-length C types,
+//     so the element stride must come from the C type size.
+// ============================================================================
+TEST_F(ArrayBindingTest, ColumnWiseFixedLengthBufferLengthZero) {
+    SKIP_ON_FIREBIRD6();
+    ExecIgnoreError("DROP TABLE ARRAY_BIND_TEST");
+    Commit();
+    ReallocStmt();
+    ExecDirect("CREATE TABLE ARRAY_BIND_TEST (I INTEGER, V BIGINT)");
+    Commit();
+    ReallocStmt();
+
+    const int N = 5;
+    SQLINTEGER ids[N] = {1, 2, 3, 4, 5};
+    SQLBIGINT vals[N] = {10, 20, 30, 40, 50};
+    SQLLEN id_ind[N] = {0, 0, 0, 0, 0};
+    SQLLEN val_ind[N] = {0, 0, SQL_NULL_DATA, 0, 0};
+    SQLUSMALLINT status[N] = {};
+    SQLULEN nprocessed = 0;
+    SQLRETURN ret;
+
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)(intptr_t)N, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &nprocessed, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAM_STATUS_PTR, status, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    ret = SQLPrepare(hStmt, (SQLCHAR*)"INSERT INTO ARRAY_BIND_TEST (I, V) VALUES (?, ?)", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    // BufferLength = 0 on both parameters
+    ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
+                           ids, 0, id_ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT, SQL_C_SBIGINT, SQL_BIGINT, 0, 0,
+                           vals, 0, val_ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    ret = SQLExecute(hStmt);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(nprocessed, (SQLULEN)N);
+    for (int i = 0; i < N; i++) {
+        EXPECT_EQ(status[i], SQL_PARAM_SUCCESS) << "Row " << i;
+    }
+    Commit();
+    ReallocStmt();
+
+    ret = SQLExecDirect(hStmt, (SQLCHAR*)"SELECT I, V FROM ARRAY_BIND_TEST ORDER BY I", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLINTEGER id = 0;
+    SQLBIGINT val = 0;
+    SQLLEN idInd = 0, valInd = 0;
+    SQLBindCol(hStmt, 1, SQL_C_SLONG, &id, sizeof(id), &idInd);
+    SQLBindCol(hStmt, 2, SQL_C_SBIGINT, &val, sizeof(val), &valInd);
+    for (int i = 0; i < N; i++) {
+        ret = SQLFetch(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << "Row " << i;
+        EXPECT_EQ(id, ids[i]) << "Row " << i;
+        if (val_ind[i] == SQL_NULL_DATA) {
+            EXPECT_EQ(valInd, SQL_NULL_DATA) << "Row " << i;
+        } else {
+            EXPECT_NE(valInd, SQL_NULL_DATA) << "Row " << i;
+            EXPECT_EQ(val, vals[i]) << "Row " << i;
+        }
+    }
+    EXPECT_EQ(SQLFetch(hStmt), SQL_NO_DATA);
+}
+
+// ============================================================================
+// 19. Column-wise binding, BufferLength = 0 across DOUBLE, DATE and TIMESTAMP
+// ============================================================================
+TEST_F(ArrayBindingTest, ColumnWiseFixedLengthTypesBufferLengthZero) {
+    SKIP_ON_FIREBIRD6();
+    ExecIgnoreError("DROP TABLE ARRAY_BIND_TEST");
+    Commit();
+    ReallocStmt();
+    ExecDirect("CREATE TABLE ARRAY_BIND_TEST (I INTEGER, D DOUBLE PRECISION, DT DATE, TS TIMESTAMP)");
+    Commit();
+    ReallocStmt();
+
+    const int N = 3;
+    SQLINTEGER ids[N] = {1, 2, 3};
+    double dbls[N] = {1.5, 2.5, 3.5};
+    SQL_DATE_STRUCT dates[N] = {};
+    SQL_TIMESTAMP_STRUCT stamps[N] = {};
+    SQLLEN ind[N] = {0, 0, 0};
+    SQLULEN nprocessed = 0;
+    SQLRETURN ret;
+
+    for (int i = 0; i < N; i++) {
+        dates[i].year = (SQLSMALLINT)(2020 + i);
+        dates[i].month = (SQLUSMALLINT)(1 + i);
+        dates[i].day = (SQLUSMALLINT)(10 + i);
+        stamps[i].year = (SQLSMALLINT)(2021 + i);
+        stamps[i].month = (SQLUSMALLINT)(2 + i);
+        stamps[i].day = (SQLUSMALLINT)(20 + i);
+        stamps[i].hour = (SQLUSMALLINT)i;
+        stamps[i].minute = 30;
+        stamps[i].second = 45;
+        stamps[i].fraction = 0;
+    }
+
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAM_BIND_TYPE, SQL_PARAM_BIND_BY_COLUMN, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)(intptr_t)N, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLSetStmtAttr(hStmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &nprocessed, 0);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    ret = SQLBindParameter(hStmt, 1, SQL_PARAM_INPUT, SQL_C_SLONG, SQL_INTEGER, 0, 0,
+                           ids, 0, ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLBindParameter(hStmt, 2, SQL_PARAM_INPUT, SQL_C_DOUBLE, SQL_DOUBLE, 0, 0,
+                           dbls, 0, ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLBindParameter(hStmt, 3, SQL_PARAM_INPUT, SQL_C_TYPE_DATE, SQL_TYPE_DATE, 0, 0,
+                           dates, 0, ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+    ret = SQLBindParameter(hStmt, 4, SQL_PARAM_INPUT, SQL_C_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP, 0, 0,
+                           stamps, 0, ind);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret));
+
+    ret = SQLExecDirect(hStmt, (SQLCHAR*)"INSERT INTO ARRAY_BIND_TEST (I, D, DT, TS) VALUES (?, ?, ?, ?)", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(nprocessed, (SQLULEN)N);
+    Commit();
+    ReallocStmt();
+
+    ret = SQLExecDirect(hStmt, (SQLCHAR*)"SELECT I, D, DT, TS FROM ARRAY_BIND_TEST ORDER BY I", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLINTEGER id = 0;
+    double dbl = 0;
+    SQL_DATE_STRUCT date = {};
+    SQL_TIMESTAMP_STRUCT stamp = {};
+    SQLLEN idInd = 0, dblInd = 0, dateInd = 0, stampInd = 0;
+    SQLBindCol(hStmt, 1, SQL_C_SLONG, &id, sizeof(id), &idInd);
+    SQLBindCol(hStmt, 2, SQL_C_DOUBLE, &dbl, sizeof(dbl), &dblInd);
+    SQLBindCol(hStmt, 3, SQL_C_TYPE_DATE, &date, sizeof(date), &dateInd);
+    SQLBindCol(hStmt, 4, SQL_C_TYPE_TIMESTAMP, &stamp, sizeof(stamp), &stampInd);
+    for (int i = 0; i < N; i++) {
+        ret = SQLFetch(hStmt);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << "Row " << i;
+        EXPECT_EQ(id, ids[i]) << "Row " << i;
+        EXPECT_DOUBLE_EQ(dbl, dbls[i]) << "Row " << i;
+        EXPECT_EQ(date.year, dates[i].year) << "Row " << i;
+        EXPECT_EQ(date.month, dates[i].month) << "Row " << i;
+        EXPECT_EQ(date.day, dates[i].day) << "Row " << i;
+        EXPECT_EQ(stamp.year, stamps[i].year) << "Row " << i;
+        EXPECT_EQ(stamp.month, stamps[i].month) << "Row " << i;
+        EXPECT_EQ(stamp.day, stamps[i].day) << "Row " << i;
+        EXPECT_EQ(stamp.hour, stamps[i].hour) << "Row " << i;
+        EXPECT_EQ(stamp.minute, stamps[i].minute) << "Row " << i;
+        EXPECT_EQ(stamp.second, stamps[i].second) << "Row " << i;
+    }
+    EXPECT_EQ(SQLFetch(hStmt), SQL_NO_DATA);
 }


### PR DESCRIPTION
Fixes #299.

## The problem

`SQLBindParameter` stores `BufferLength` as the element stride of a column-wise parameter array (`sizeColumnExtendedFetch`). The ODBC specification ignores `BufferLength` for fixed-length C types and applications pass 0 there, so `inputParam` multiplied the set number by 0 and every parameter set read element 0. `SQLExecute` returned `SQL_SUCCESS`, `SQL_ATTR_PARAMS_PROCESSED_PTR` said N and the status array was all `SQL_PARAM_SUCCESS`; the table held N copies of the first set. `SQL_C_CHAR` arrays were stepped correctly because there `BufferLength` is the element size, which is why the string-only tests never saw it.

The output side has always had the fallback: `bindOutputColumn` computes the stride from the C type when `SQLBindCol` gets 0. The input side never did.

A second defect sits on the same path. The executor is chosen at prepare time (`execute = &executeStatementParamArray` only if the paramset size is already greater than 1). An application that prepares first and sets `SQL_ATTR_PARAMSET_SIZE` afterwards, which the specification allows, gets `executeStatement` once: one row, first parameter set, `SQL_SUCCESS`. pyodbc's `fast_executemany` does exactly that sequence; against master a five-row `executemany` stores one row.

Two of the issue's observations are not defects:

- The indicator array is stepped correctly since 0a7cc1f (#279). In the report every id collapsed to 1 because the id column was bound the same way, so `ORDER BY id` over equal keys returned the rows in arbitrary order and the NULL appeared to move.
- `SQLRowCount` = 1 after an array execute matches the `SQL_PARC_BATCH` the driver reports for `SQL_PARAM_ARRAY_ROW_COUNTS`: the count is per parameter set. What is missing is `SQLMoreResults` stepping to the next set's count; not touched here.

## The fix

Three commits.

1. `tests:` eleven `ArrayBindingTest` cases were skipped citing a crash in the indicator offset that #279 fixed. The skips come out, with the Firebird 6 guard the row-wise cases already carry; `ParamOperationPtrSkipRows` stays skipped for the reason its row-wise twin gives. Two new cases bind fixed-length C types with `BufferLength = 0`: the shape from the issue (`INTEGER` and `BIGINT`, NULL in the third set) and `DOUBLE` / `DATE` / `TIMESTAMP`.
2. `bindInputOutputParam` falls back to `getConciseSize` when the stride is 0, the same switch `bindOutputColumn` uses. `getConciseSize` gains `SQL_C_GUID`, for which it returned the type code (-11), a negative stride on either side.
3. `sqlExecute` and `sqlExecDirect` switch to `executeStatementParamArray` when the paramset size is greater than 1 at execute time and the prepare-time choice was something else.

## Tests

On master (35fae3e) with the skips removed, 3 of the 17 active array cases fail: `ColumnWisePrepareExecute` (sets the paramset size after `SQLPrepare`) and the two new cases. With this branch all 17 pass; the two `OPERATION_PTR` cases stay skipped.

A ctypes port of the issue's program, extended with the prepare-then-set-paramset order and pyodbc `fast_executemany`. Windows x64, Firebird 5.0.3, Microsoft driver manager:

| case | master | this branch |
|---|---|---|
| column-wise, `BufferLength = 0` | `(1,NULL) (1,10) (1,10) (1,10) (1,10)` | `(1,10) (2,20) (3,NULL) (4,40) (5,50)` |
| column-wise, `BufferLength = sizeof(type)` | correct | correct |
| row-wise | correct | correct |
| column-wise, `SQL_ATTR_PARAMSET_SIZE` set after `SQLPrepare` | `(1,10)` | correct |
| pyodbc `fast_executemany`, five rows | `(1,10)` | correct |

Full suite with this branch, `CHARSET=UTF8` and `NONE`: 390 ran, 235 passed, 155 skipped, 0 failed.

## Still open

- `SQL_ATTR_PARAM_OPERATION_PTR` is ignored (`ParamOperationPtrSkipRows` and `RowWiseWithOperationPtr` stay skipped).
- `SQLMoreResults` after an array execute does not step through the per-set row counts.
- #306, the fetch-side twin (column-wise `SQLBindCol` with `SQL_ATTR_ROW_BIND_OFFSET_PTR`), is a different branch of `fetchData` and is not touched here.
- The v5 RFC (#283) already carries both fixes.
