### PR TITLE
Implementation descriptors and SQLColAttribute report the columns and parameters they describe (#316)

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -1011,7 +1011,7 @@ SQLRETURN SQL_API SQLCloseCursor  (SQLHSTMT arg0)
 SQLRETURN SQL_API SQLColAttribute( SQLHSTMT hStmt, SQLUSMALLINT columnNumber,
 									SQLUSMALLINT fieldIdentifier, SQLPOINTER characterAttribute,
 									SQLSMALLINT bufferLength, SQLSMALLINT *stringLength,
-#ifdef _WIN64
+#if defined(_WIN64) || !defined(_WIN32)
 									SQLLEN *numericAttribute )
 #else
 									SQLPOINTER numericAttribute )

--- a/MainUnicode.cpp
+++ b/MainUnicode.cpp
@@ -887,7 +887,7 @@ SQLRETURN SQL_API SQLDriversW( SQLHENV hEnv, SQLUSMALLINT fDirection,
 SQLRETURN SQL_API SQLColAttributeW( SQLHSTMT hStmt, SQLUSMALLINT columnNumber,
 								   SQLUSMALLINT fieldIdentifier, SQLPOINTER characterAttribute,
 								   SQLSMALLINT bufferLength, SQLSMALLINT *stringLength,
-#ifdef _WIN64
+#if defined(_WIN64) || !defined(_WIN32)
 								   SQLLEN *numericAttribute )
 #else
 								   SQLPOINTER numericAttribute )

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -331,6 +331,41 @@ OdbcObjectType OdbcDesc::getType()
 	return odbcTypeDescriptor;
 }
 
+// An implementation row record keeps the concise SQL type in `type` and the
+// converter's C type in `conciseType`. The descriptor API reports ODBC's
+// verbose type, concise type and datetime interval code, all derived from
+// the SQL type.
+static SQLSMALLINT verboseSqlType( int sqlType )
+{
+	switch ( sqlType )
+	{
+	case SQL_TYPE_DATE:
+	case SQL_TYPE_TIME:
+	case SQL_TYPE_TIMESTAMP:
+	case SQL_TIME:
+	case SQL_TIMESTAMP:
+		return SQL_DATETIME;
+	}
+	return (SQLSMALLINT)sqlType;
+}
+
+static SQLSMALLINT datetimeIntervalCodeOf( int sqlType )
+{
+	switch ( sqlType )
+	{
+	case SQL_TYPE_DATE:
+	case SQL_DATE:
+		return SQL_CODE_DATE;
+	case SQL_TYPE_TIME:
+	case SQL_TIME:
+		return SQL_CODE_TIME;
+	case SQL_TYPE_TIMESTAMP:
+	case SQL_TIMESTAMP:
+		return SQL_CODE_TIMESTAMP;
+	}
+	return 0;
+}
+
 SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, int bufferLength, SQLINTEGER *lengthPtr)
 {
     clearErrors();
@@ -475,19 +510,19 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 // Record
 		case SQL_DESC_TYPE:
 			if (record && ptr)
-				*(SQLSMALLINT*) ptr = record->type,
+				*(SQLSMALLINT*) ptr = headType == odtImplementationRow ? verboseSqlType( record->type ) : record->type,
 				size = sizeof (SQLSMALLINT);
 			break;
 
 		case SQL_DESC_DATETIME_INTERVAL_CODE:
 			if (record && ptr)
-				*(SQLSMALLINT*) ptr = record->datetimeIntervalCode,
+				*(SQLSMALLINT*) ptr = headType == odtImplementationRow ? datetimeIntervalCodeOf( record->type ) : record->datetimeIntervalCode,
 				size = sizeof (SQLSMALLINT);
 			break;
 
 		case SQL_DESC_CONCISE_TYPE:
 			if (record && ptr)
-				*(SQLSMALLINT*) ptr = record->conciseType,
+				*(SQLSMALLINT*) ptr = headType == odtImplementationRow ? record->type : record->conciseType,
 				size = sizeof (SQLSMALLINT);
 			break;
 
@@ -1236,8 +1271,8 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 		if( rc )
 			return rc;
 
-		*typePtr = record->type;
-		*subTypePtr = record->datetimeIntervalCode;
+		*typePtr = headType == odtImplementationRow ? verboseSqlType( record->type ) : record->type;
+		*subTypePtr = headType == odtImplementationRow ? datetimeIntervalCodeOf( record->type ) : record->datetimeIntervalCode;
 		*lengthPtr = record->octetLength;
 		*precisionPtr = record->precision;
 		*scalePtr = record->scale;

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -336,7 +336,22 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 	DescRecord *record = NULL;
 
 	if ( bDefined == false )
-		return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
+	{
+		switch (fieldId)
+		{
+		case SQL_DESC_ALLOC_TYPE:
+		case SQL_DESC_ARRAY_SIZE:
+		case SQL_DESC_ARRAY_STATUS_PTR:
+		case SQL_DESC_BIND_OFFSET_PTR:
+		case SQL_DESC_BIND_TYPE:
+		case SQL_DESC_ROWS_PROCESSED_PTR:
+			break;	// header fields do not depend on the result set
+		default:
+			if ( headType == odtImplementationRow )
+				return sqlReturn (SQL_ERROR, "HY007", "Associated statement is not prepared");
+			return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
+		}
+	}
 
 	if ( recNumber > headCount )
 		return sqlReturn (SQL_NO_DATA_FOUND, "HY021", "Inconsistent descriptor information");

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -216,6 +216,9 @@ SQLRETURN OdbcDesc::operator =(OdbcDesc &sour)
 
 		if ( srcrec )
 		{
+			if ( sour.headType == odtImplementationRow && n && !srcrec->isDefined )
+				sour.defFromMetaDataOut( n, srcrec );
+
 			rec = srcrec;
 			rec.sizeColumnExtendedFetch = srcrec->sizeColumnExtendedFetch;
 		}
@@ -371,6 +374,8 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 			if ( !recNumber && headType == odtImplementationParameter )
 					return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
 			record = getDescRecord (recNumber);
+			if ( headType == odtImplementationRow && recNumber && !record->isDefined )
+				defFromMetaDataOut( recNumber, record );
 	}
 
 	try
@@ -1222,6 +1227,8 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 			return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
 
 	record = getDescRecord (recNumber);
+	if ( headType == odtImplementationRow && recNumber && !record->isDefined )
+		defFromMetaDataOut( recNumber, record );
 
 	try
 	{

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -216,8 +216,7 @@ SQLRETURN OdbcDesc::operator =(OdbcDesc &sour)
 
 		if ( srcrec )
 		{
-			if ( sour.headType == odtImplementationRow && n && !srcrec->isDefined )
-				sour.defFromMetaDataOut( n, srcrec );
+			sour.defineImplRecord( n, srcrec );
 
 			rec = srcrec;
 			rec.sizeColumnExtendedFetch = srcrec->sizeColumnExtendedFetch;
@@ -331,13 +330,31 @@ OdbcObjectType OdbcDesc::getType()
 	return odbcTypeDescriptor;
 }
 
-// An implementation row record keeps the concise SQL type in `type` and the
+// An implementation record keeps the concise SQL type in `type` and the
 // converter's C type in `conciseType`. The descriptor API reports ODBC's
 // verbose type, concise type and datetime interval code, all derived from
-// the SQL type.
-static SQLSMALLINT verboseSqlType( int sqlType )
+// the SQL type; an application may also have stored the verbose form with
+// its interval code in an IPD record.
+SQLSMALLINT OdbcDesc::conciseSqlType( int type, int datetimeIntervalCode )
 {
-	switch ( sqlType )
+	if ( type == SQL_DATETIME )
+	{
+		switch ( datetimeIntervalCode )
+		{
+		case SQL_CODE_DATE:
+			return SQL_TYPE_DATE;
+		case SQL_CODE_TIME:
+			return SQL_TYPE_TIME;
+		case SQL_CODE_TIMESTAMP:
+			return SQL_TYPE_TIMESTAMP;
+		}
+	}
+	return (SQLSMALLINT)type;
+}
+
+SQLSMALLINT OdbcDesc::verboseSqlType( int conciseSqlType )
+{
+	switch ( conciseSqlType )
 	{
 	case SQL_TYPE_DATE:
 	case SQL_TYPE_TIME:
@@ -346,15 +363,14 @@ static SQLSMALLINT verboseSqlType( int sqlType )
 	case SQL_TIMESTAMP:
 		return SQL_DATETIME;
 	}
-	return (SQLSMALLINT)sqlType;
+	return (SQLSMALLINT)conciseSqlType;
 }
 
-static SQLSMALLINT datetimeIntervalCodeOf( int sqlType )
+SQLSMALLINT OdbcDesc::datetimeIntervalCodeOf( int conciseSqlType )
 {
-	switch ( sqlType )
+	switch ( conciseSqlType )
 	{
 	case SQL_TYPE_DATE:
-	case SQL_DATE:
 		return SQL_CODE_DATE;
 	case SQL_TYPE_TIME:
 	case SQL_TIME:
@@ -366,12 +382,37 @@ static SQLSMALLINT datetimeIntervalCodeOf( int sqlType )
 	return 0;
 }
 
+// SQLPrepare sizes the implementation descriptors but fills a record only
+// when its column or parameter is bound or the statement executes. The
+// descriptor API fills it the same way before reading or copying it.
+void OdbcDesc::defineImplRecord( int recNumber, DescRecord * record )
+{
+	if ( !recNumber || record->isDefined )
+		return;
+
+	if ( headType == odtImplementationRow )
+	{
+		if ( metaDataOut )
+			defFromMetaDataOut( recNumber, record );
+	}
+	else if ( headType == odtImplementationParameter )
+	{
+		int countIn = metaDataIn ? metaDataIn->getColumnCount() : 0;
+
+		if ( recNumber <= countIn )
+			defFromMetaDataIn( recNumber, record );
+		else if ( metaDataOut && recNumber - countIn <= metaDataOut->getColumnCount() )
+			defFromMetaDataOut( recNumber - countIn, record );
+	}
+}
+
 SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, int bufferLength, SQLINTEGER *lengthPtr)
 {
     clearErrors();
 	SQLINTEGER size = 0;
 	SQLCHAR *string = NULL;
 	DescRecord *record = NULL;
+	const bool implRecord = headType == odtImplementationRow || headType == odtImplementationParameter;
 
 	if ( bDefined == false )
 	{
@@ -409,8 +450,7 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 			if ( !recNumber && headType == odtImplementationParameter )
 					return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
 			record = getDescRecord (recNumber);
-			if ( headType == odtImplementationRow && recNumber && !record->isDefined )
-				defFromMetaDataOut( recNumber, record );
+			defineImplRecord( recNumber, record );
 	}
 
 	try
@@ -510,19 +550,19 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 // Record
 		case SQL_DESC_TYPE:
 			if (record && ptr)
-				*(SQLSMALLINT*) ptr = headType == odtImplementationRow ? verboseSqlType( record->type ) : record->type,
+				*(SQLSMALLINT*) ptr = implRecord ? verboseSqlType( conciseSqlType( record->type, record->datetimeIntervalCode ) ) : record->type,
 				size = sizeof (SQLSMALLINT);
 			break;
 
 		case SQL_DESC_DATETIME_INTERVAL_CODE:
 			if (record && ptr)
-				*(SQLSMALLINT*) ptr = headType == odtImplementationRow ? datetimeIntervalCodeOf( record->type ) : record->datetimeIntervalCode,
+				*(SQLSMALLINT*) ptr = implRecord ? datetimeIntervalCodeOf( conciseSqlType( record->type, record->datetimeIntervalCode ) ) : record->datetimeIntervalCode,
 				size = sizeof (SQLSMALLINT);
 			break;
 
 		case SQL_DESC_CONCISE_TYPE:
 			if (record && ptr)
-				*(SQLSMALLINT*) ptr = headType == odtImplementationRow ? record->type : record->conciseType,
+				*(SQLSMALLINT*) ptr = implRecord ? conciseSqlType( record->type, record->datetimeIntervalCode ) : record->conciseType,
 				size = sizeof (SQLSMALLINT);
 			break;
 
@@ -1253,7 +1293,11 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 	DescRecord *record = NULL;
 
 	if ( bDefined == false )
+	{
+		if ( headType == odtImplementationRow )
+			return sqlReturn (SQL_ERROR, "HY007", "Associated statement is not prepared");
 		return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
+	}
 
 	if ( recNumber > headCount )
 		return sqlReturn (SQL_NO_DATA_FOUND, "HY021", "Inconsistent descriptor information");
@@ -1262,8 +1306,8 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 			return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
 
 	record = getDescRecord (recNumber);
-	if ( headType == odtImplementationRow && recNumber && !record->isDefined )
-		defFromMetaDataOut( recNumber, record );
+	defineImplRecord( recNumber, record );
+	const bool implRecord = headType == odtImplementationRow || headType == odtImplementationParameter;
 
 	try
 	{
@@ -1271,8 +1315,8 @@ SQLRETURN OdbcDesc::sqlGetDescRec(	SQLSMALLINT recNumber,
 		if( rc )
 			return rc;
 
-		*typePtr = headType == odtImplementationRow ? verboseSqlType( record->type ) : record->type;
-		*subTypePtr = headType == odtImplementationRow ? datetimeIntervalCodeOf( record->type ) : record->datetimeIntervalCode;
+		*typePtr = implRecord ? verboseSqlType( conciseSqlType( record->type, record->datetimeIntervalCode ) ) : record->type;
+		*subTypePtr = implRecord ? datetimeIntervalCodeOf( conciseSqlType( record->type, record->datetimeIntervalCode ) ) : record->datetimeIntervalCode;
 		*lengthPtr = record->octetLength;
 		*precisionPtr = record->precision;
 		*scalePtr = record->scale;

--- a/OdbcDesc.cpp
+++ b/OdbcDesc.cpp
@@ -591,8 +591,8 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 			if(headType ==  odtImplementationRow)
 			{
 				if (record && ptr)
-					*(SQLINTEGER*) ptr = record->displaySize,
-					size = sizeof (SQLINTEGER);
+					*(SQLLEN*) ptr = record->displaySize,
+					size = sizeof (SQLLEN);
 			}
 			else
 				return sqlReturn (SQL_ERROR, "HY091", "Invalid descriptor field identifier");
@@ -654,8 +654,8 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 
 		case SQL_DESC_LENGTH:
 			if (record && ptr)
-				*(SQLUINTEGER*) ptr = record->length,
-				size = sizeof (SQLUINTEGER);
+				*(SQLULEN*) ptr = record->length,
+				size = sizeof (SQLULEN);
 			break;
 
 		case SQL_DESC_NAME:
@@ -693,8 +693,8 @@ SQLRETURN OdbcDesc::sqlGetDescField(int recNumber, int fieldId, SQLPOINTER ptr, 
 			
 		case SQL_DESC_OCTET_LENGTH:
 			if (record && ptr)
-				*(SQLINTEGER*) ptr = record->octetLength,
-				size = sizeof (SQLINTEGER);	
+				*(SQLLEN*) ptr = record->octetLength,
+				size = sizeof (SQLLEN);
 			break;
 			
 		case SQL_DESC_OCTET_LENGTH_PTR:

--- a/OdbcDesc.h
+++ b/OdbcDesc.h
@@ -116,6 +116,10 @@ public:
 	void defFromMetaDataOut(int recNumber, DescRecord * record);
 	int getConciseType(int type);
 	int getConciseSize(int type, int length);
+	void defineImplRecord(int recNumber, DescRecord * record);
+	static SQLSMALLINT conciseSqlType(int type, int datetimeIntervalCode);
+	static SQLSMALLINT verboseSqlType(int conciseSqlType);
+	static SQLSMALLINT datetimeIntervalCodeOf(int conciseSqlType);
 	int getDefaultFromSQLToConciseType(int sqlType, int bufferLength = 0);
 
 //Head

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -174,6 +174,7 @@ OdbcStatement::OdbcStatement(OdbcConnection *connect, int statementNumber)
 	statement = connection->connection->createInternalStatement();
 	bulkInsert = NULL;
 	execute = &OdbcStatement::executeStatement;
+	keysetSize = 0;
 	fetchNext = &ResultSet::nextFetch;
 	schemaFetchData = true;
 	metaData = NULL;
@@ -2577,6 +2578,11 @@ SQLRETURN OdbcStatement::sqlGetStmtAttr(int attribute, SQLPOINTER ptr, int buffe
 			TRACE02(SQL_ROWSET_SIZE,value);
 			break;
 
+		case SQL_ATTR_KEYSET_SIZE:
+			value = keysetSize;
+			TRACE02(SQL_ATTR_KEYSET_SIZE,value);
+			break;
+
 		case SQL_ATTR_MAX_ROWS:					// SQL_MAX_ROWS 1
 			value = maxRows;
 			TRACE02(SQL_ATTR_MAX_ROWS,value);
@@ -3434,6 +3440,10 @@ SQLRETURN OdbcStatement::sqlSetStmtAttr(int attribute, SQLPOINTER ptr, int lengt
 			break;
 
 		case SQL_ATTR_KEYSET_SIZE:           // 8
+			keysetSize = (uintptr_t) ptr;
+			TRACE02(SQL_ATTR_KEYSET_SIZE,(intptr_t) ptr);
+		    break;
+
 		case SQL_ROWSET_SIZE:                // 9
 			applicationRowDescriptor->headArraySize = (intptr_t) ptr;
 			TRACE02(SQL_ROWSET_SIZE,(intptr_t) ptr);

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -3714,9 +3714,16 @@ SQLRETURN OdbcStatement::sqlColAttribute( int column, int fieldId, SQLPOINTER at
 				value = metaData->getColumnCount();
 			break;
 
-		case SQL_DESC_TYPE:
 		case SQL_DESC_CONCISE_TYPE:
 			value = metaData->getColumnType (column, realSqlType);
+			break;
+
+		case SQL_DESC_TYPE:
+			value = OdbcDesc::verboseSqlType( metaData->getColumnType (column, realSqlType) );
+			break;
+
+		case SQL_DESC_DATETIME_INTERVAL_CODE:
+			value = OdbcDesc::datetimeIntervalCodeOf( metaData->getColumnType (column, realSqlType) );
 			break;
 
 		case SQL_COLUMN_LENGTH:

--- a/OdbcStatement.cpp
+++ b/OdbcStatement.cpp
@@ -3668,7 +3668,7 @@ SQLRETURN OdbcStatement::sqlRowCount(SQLLEN *rowCount)
 	return sqlSuccess();
 }
 
-#ifdef _WIN64
+#if defined(_WIN64) || !defined(_WIN32)
 SQLRETURN OdbcStatement::sqlColAttribute( int column, int fieldId, SQLPOINTER attributePtr, int bufferLength, SQLSMALLINT *strLengthPtr, SQLLEN *numericAttributePtr )
 #else
 SQLRETURN OdbcStatement::sqlColAttribute( int column, int fieldId, SQLPOINTER attributePtr, int bufferLength, SQLSMALLINT *strLengthPtr, SQLPOINTER numericAttributePtr )
@@ -3820,13 +3820,8 @@ SQLRETURN OdbcStatement::sqlColAttribute( int column, int fieldId, SQLPOINTER at
 		setString (string, (SQLCHAR*) attributePtr, bufferLength, strLengthPtr);
 	else if (numericAttributePtr)
 	{
-#ifdef _WIN64
 		*(SQLLEN*) numericAttributePtr = value;
 		if ( strLengthPtr ) *strLengthPtr = sizeof ( SQLLEN );
-#else
-		*(SQLINTEGER*) numericAttributePtr = value;
-		if ( strLengthPtr ) *strLengthPtr = sizeof ( SQLINTEGER );
-#endif
 	}
 
 	return sqlSuccess();

--- a/OdbcStatement.h
+++ b/OdbcStatement.h
@@ -192,6 +192,7 @@ public:
 	bool				asyncEnable;
 	int					rowNumber;
 	int					rowNumberParamArray;
+	SQLULEN				keysetSize;
 	int					lastRowsetSize;
 	SQLLEN				indicatorRowNumber;
 	int					maxRows;

--- a/OdbcStatement.h
+++ b/OdbcStatement.h
@@ -62,7 +62,7 @@ public:
 	inline SQLRETURN fetchData();
 	inline SQLRETURN returnData();
 	inline SQLRETURN returnDataFromExtendedFetch();
-#ifdef _WIN64
+#if defined(_WIN64) || !defined(_WIN32)
 	SQLRETURN sqlColAttribute( int column, int fieldId, SQLPOINTER attributePtr, int bufferLength, SQLSMALLINT *strLengthPtr, SQLLEN *numericAttributePtr );
 #else
 	SQLRETURN sqlColAttribute( int column, int fieldId, SQLPOINTER attributePtr, int bufferLength, SQLSMALLINT *strLengthPtr, SQLPOINTER numericAttributePtr );

--- a/tests/test_descriptor.cpp
+++ b/tests/test_descriptor.cpp
@@ -366,3 +366,59 @@ TEST_F(CopyDescCrashTest, SetDescCountToZeroUnbindsAll) {
 
     SQLFreeHandle(SQL_HANDLE_DESC, hDesc);
 }
+
+// ===== IRD before SQLPrepare (#307) =====
+TEST_F(DescriptorTest, IrdHeaderFieldsReadableBeforePrepare) {
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+    ASSERT_NE(hIrd, (SQLHDESC)SQL_NULL_HDESC);
+
+    SQLULEN rowsFetched = 0;
+    SQLUSMALLINT rowStatus[4] = {};
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ATTR_ROWS_FETCHED_PTR, &rowsFetched, 0)));
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ATTR_ROW_STATUS_PTR, rowStatus, 0)));
+
+    SQLPOINTER ptr = NULL;
+    SQLRETURN ret = SQLGetDescField(hIrd, 0, SQL_DESC_ROWS_PROCESSED_PTR, &ptr, 0, NULL);
+    if (ret == SQL_ERROR && GetSqlState(SQL_HANDLE_DESC, hIrd) == "HY007") {
+        // unixODBC answers HY007 for an unprepared IRD before the driver sees the call
+        GTEST_SKIP() << "the driver manager enforces HY007 itself: " << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+    }
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+    EXPECT_EQ(ptr, (SQLPOINTER)&rowsFetched);
+
+    ptr = NULL;
+    ret = SQLGetDescField(hIrd, 0, SQL_DESC_ARRAY_STATUS_PTR, &ptr, 0, NULL);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+    EXPECT_EQ(ptr, (SQLPOINTER)rowStatus);
+
+    SQLSMALLINT allocType = 0;
+    ret = SQLGetDescField(hIrd, 0, SQL_DESC_ALLOC_TYPE, &allocType, 0, NULL);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+    EXPECT_EQ(allocType, SQL_DESC_ALLOC_AUTO);
+}
+
+TEST_F(DescriptorTest, IrdRecordFieldsBeforePrepareAreHY007) {
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+    ASSERT_NE(hIrd, (SQLHDESC)SQL_NULL_HDESC);
+
+    SQLSMALLINT count = -1;
+    SQLRETURN ret = SQLGetDescField(hIrd, 0, SQL_DESC_COUNT, &count, 0, NULL);
+    EXPECT_EQ(ret, SQL_ERROR);
+    EXPECT_EQ(GetSqlState(SQL_HANDLE_DESC, hIrd), "HY007");
+
+    SQLSMALLINT type = 0;
+    ret = SQLGetDescField(hIrd, 1, SQL_DESC_TYPE, &type, 0, NULL);
+    EXPECT_EQ(ret, SQL_ERROR);
+    EXPECT_EQ(GetSqlState(SQL_HANDLE_DESC, hIrd), "HY007");
+
+    // Both answer once the statement is prepared
+    ret = SQLPrepare(hStmt, (SQLCHAR*)"SELECT 1 AS A FROM RDB$DATABASE", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    ret = SQLGetDescField(hIrd, 0, SQL_DESC_COUNT, &count, 0, NULL);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+    EXPECT_EQ(count, 1);
+    ret = SQLGetDescField(hIrd, 1, SQL_DESC_TYPE, &type, 0, NULL);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+}

--- a/tests/test_descriptor.cpp
+++ b/tests/test_descriptor.cpp
@@ -545,3 +545,130 @@ TEST_F(DescriptorTest, IrdTypeFieldsFollowOdbc) {
         EXPECT_EQ(recSubType, e.intervalCode) << "column " << e.col;
     }
 }
+
+// ===== Length fields are written at full width (#316) =====
+TEST_F(DescriptorTest, IrdLengthFieldsAreFullWidth) {
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"SELECT CAST(1 AS INTEGER) AS A FROM RDB$DATABASE", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+
+    struct { SQLUSMALLINT field; const char* name; } fields[] = {
+        {SQL_DESC_LENGTH, "SQL_DESC_LENGTH"},
+        {SQL_DESC_OCTET_LENGTH, "SQL_DESC_OCTET_LENGTH"},
+        {SQL_DESC_DISPLAY_SIZE, "SQL_DESC_DISPLAY_SIZE"},
+    };
+    for (auto& f : fields) {
+        // The same read into a zeroed and into an all-ones SQLLEN: a 32-bit write
+        // leaves the upper half of the second one set and the two differ.
+        SQLLEN zeroed = 0, poisoned = -1;
+        ret = SQLGetDescField(hIrd, 1, f.field, &zeroed, 0, NULL);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << f.name << ": " << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+        ret = SQLGetDescField(hIrd, 1, f.field, &poisoned, 0, NULL);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << f.name << ": " << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+        EXPECT_EQ(poisoned, zeroed) << f.name;
+        EXPECT_GT(zeroed, 0) << f.name;
+    }
+}
+
+// ===== IPD records right after SQLPrepare (#316) =====
+TEST_F(DescriptorTest, IpdRecordsDescribeParametersAfterPrepare) {
+    SKIP_ON_FIREBIRD6();
+    TempTable table(this, "ODBC_TEST_IPD", "I INTEGER NOT NULL, V VARCHAR(5), D DATE, N NUMERIC(9,2)");
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"INSERT INTO ODBC_TEST_IPD (I, V, D, N) VALUES (?, ?, ?, ?)", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLHDESC hIpd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_PARAM_DESC, &hIpd, 0, NULL)));
+
+    // A verbose type of 0 means "same as the concise type SQLDescribeParam reports"
+    struct { SQLSMALLINT par, verboseType, intervalCode; } expected[] = {
+        {1, SQL_INTEGER, 0},
+        {2, 0, 0},
+        {3, SQL_DATETIME, SQL_CODE_DATE},
+        {4, SQL_NUMERIC, 0},
+    };
+    for (auto& e : expected) {
+        SQLSMALLINT dataType = 0, decimalDigits = 0, nullable = 0;
+        SQLULEN paramSize = 0;
+        ret = SQLDescribeParam(hStmt, e.par, &dataType, &paramSize, &decimalDigits, &nullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        SQLSMALLINT verboseType = e.verboseType ? e.verboseType : dataType;
+
+        SQLSMALLINT descType = 0, conciseType = 0, intervalCode = -1, scale = -1, descNullable = -1;
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIpd, e.par, SQL_DESC_TYPE, &descType, 0, NULL)))
+            << GetOdbcError(SQL_HANDLE_DESC, hIpd);
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIpd, e.par, SQL_DESC_CONCISE_TYPE, &conciseType, 0, NULL)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIpd, e.par, SQL_DESC_DATETIME_INTERVAL_CODE, &intervalCode, 0, NULL)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIpd, e.par, SQL_DESC_SCALE, &scale, 0, NULL)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIpd, e.par, SQL_DESC_NULLABLE, &descNullable, 0, NULL)));
+        EXPECT_EQ(descType, verboseType) << "parameter " << e.par;
+        EXPECT_EQ(conciseType, dataType) << "parameter " << e.par;
+        EXPECT_EQ(intervalCode, e.intervalCode) << "parameter " << e.par;
+        EXPECT_EQ(descNullable, nullable) << "parameter " << e.par;
+        if (e.par == 4) {
+            EXPECT_EQ(scale, decimalDigits) << "NUMERIC(9,2) scale";
+        }
+
+        SQLCHAR recName[64] = {};
+        SQLSMALLINT recNameLen = 0, recType = 0, recSubType = -1, recPrecision = 0, recScale = 0,
+                    recNullable = 0;
+        SQLLEN recLength = 0;
+        ret = SQLGetDescRec(hIpd, e.par, recName, sizeof(recName), &recNameLen, &recType, &recSubType,
+                            &recLength, &recPrecision, &recScale, &recNullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIpd);
+        EXPECT_EQ(recType, verboseType) << "parameter " << e.par;
+        EXPECT_EQ(recSubType, e.intervalCode) << "parameter " << e.par;
+    }
+}
+
+// ===== SQLGetDescRec on an unprepared IRD (#307, #316) =====
+TEST_F(DescriptorTest, IrdGetDescRecBeforePrepareIsHY007) {
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+    SQLCHAR name[64] = {};
+    SQLSMALLINT nameLen = 0, type = 0, subType = 0, precision = 0, scale = 0, nullable = 0;
+    SQLLEN length = 0;
+    SQLRETURN ret = SQLGetDescRec(hIrd, 1, name, sizeof(name), &nameLen, &type, &subType,
+                                  &length, &precision, &scale, &nullable);
+    EXPECT_EQ(ret, SQL_ERROR);
+    EXPECT_EQ(GetSqlState(SQL_HANDLE_DESC, hIrd), "HY007");
+}
+
+// ===== SQLColAttribute type fields: verbose type, concise type, interval code (#316) =====
+TEST_F(DescriptorTest, ColAttributeTypeFieldsFollowOdbc) {
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"SELECT CAST(1 AS INTEGER) AS C1, CAST('x' AS VARCHAR(5)) AS C2, "
+                  "CAST('2020-01-02' AS DATE) AS C3, "
+                  "CAST('2020-01-02 03:04:05' AS TIMESTAMP) AS C4 FROM RDB$DATABASE",
+        SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    struct { SQLUSMALLINT col; SQLLEN verboseType, intervalCode; } expected[] = {
+        {1, SQL_INTEGER, 0},
+        {2, 0, 0},
+        {3, SQL_DATETIME, SQL_CODE_DATE},
+        {4, SQL_DATETIME, SQL_CODE_TIMESTAMP},
+    };
+    for (auto& e : expected) {
+        SQLCHAR colName[64] = {};
+        SQLSMALLINT colNameLen = 0, dataType = 0, decimalDigits = 0, nullable = 0;
+        SQLULEN columnSize = 0;
+        ret = SQLDescribeCol(hStmt, e.col, colName, sizeof(colName), &colNameLen, &dataType,
+                             &columnSize, &decimalDigits, &nullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        SQLLEN verboseType = e.verboseType ? e.verboseType : dataType;
+
+        SQLLEN type = 0, conciseType = 0, intervalCode = -1;
+        ret = SQLColAttribute(hStmt, e.col, SQL_DESC_TYPE, NULL, 0, NULL, &type);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        ret = SQLColAttribute(hStmt, e.col, SQL_DESC_CONCISE_TYPE, NULL, 0, NULL, &conciseType);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        ret = SQLColAttribute(hStmt, e.col, SQL_DESC_DATETIME_INTERVAL_CODE, NULL, 0, NULL, &intervalCode);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << "column " << e.col << ": " << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        EXPECT_EQ(type, verboseType) << "column " << e.col;
+        EXPECT_EQ(conciseType, (SQLLEN)dataType) << "column " << e.col;
+        EXPECT_EQ(intervalCode, e.intervalCode) << "column " << e.col;
+    }
+}

--- a/tests/test_descriptor.cpp
+++ b/tests/test_descriptor.cpp
@@ -461,7 +461,7 @@ TEST_F(DescriptorTest, IrdRecordsDescribeColumnsAfterPrepare) {
         ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
 
         EXPECT_NE(descType, SQL_C_DEFAULT) << "column " << col << " still holds the record default";
-        EXPECT_NE(conciseType, SQL_C_DEFAULT) << "column " << col;
+        EXPECT_EQ(conciseType, dataType) << "column " << col;
         EXPECT_STREQ((char*)descName, (char*)colName) << "column " << col;
         EXPECT_NE(recType, SQL_C_DEFAULT) << "column " << col;
         EXPECT_STREQ((char*)recName, (char*)colName) << "column " << col;
@@ -497,4 +497,51 @@ TEST_F(DescriptorTest, CopyDescFromIrdAfterPrepare) {
     ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hCopy);
     EXPECT_EQ(descType, dataType);
     SQLFreeHandle(SQL_HANDLE_DESC, hCopy);
+}
+
+// ===== IRD type fields: verbose type, concise type, datetime interval code (#316) =====
+TEST_F(DescriptorTest, IrdTypeFieldsFollowOdbc) {
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"SELECT CAST(1 AS INTEGER) AS C1, CAST('x' AS VARCHAR(5)) AS C2, "
+                  "CAST('2020-01-02' AS DATE) AS C3, "
+                  "CAST('2020-01-02 03:04:05' AS TIMESTAMP) AS C4 FROM RDB$DATABASE",
+        SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+
+    // A verbose type of 0 means "same as the concise type SQLDescribeCol reports"
+    struct { SQLSMALLINT col, verboseType, intervalCode; } expected[] = {
+        {1, SQL_INTEGER, 0},
+        {2, 0, 0},
+        {3, SQL_DATETIME, SQL_CODE_DATE},
+        {4, SQL_DATETIME, SQL_CODE_TIMESTAMP},
+    };
+    for (auto& e : expected) {
+        SQLCHAR colName[64] = {};
+        SQLSMALLINT colNameLen = 0, dataType = 0, decimalDigits = 0, nullable = 0;
+        SQLULEN columnSize = 0;
+        ret = SQLDescribeCol(hStmt, e.col, colName, sizeof(colName), &colNameLen, &dataType,
+                             &columnSize, &decimalDigits, &nullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+        SQLSMALLINT verboseType = e.verboseType ? e.verboseType : dataType;
+
+        SQLSMALLINT descType = 0, conciseType = 0, intervalCode = -1;
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIrd, e.col, SQL_DESC_TYPE, &descType, 0, NULL)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIrd, e.col, SQL_DESC_CONCISE_TYPE, &conciseType, 0, NULL)));
+        ASSERT_TRUE(SQL_SUCCEEDED(SQLGetDescField(hIrd, e.col, SQL_DESC_DATETIME_INTERVAL_CODE, &intervalCode, 0, NULL)));
+        EXPECT_EQ(descType, verboseType) << "column " << e.col;
+        EXPECT_EQ(conciseType, dataType) << "column " << e.col;
+        EXPECT_EQ(intervalCode, e.intervalCode) << "column " << e.col;
+
+        SQLCHAR recName[64] = {};
+        SQLSMALLINT recNameLen = 0, recType = 0, recSubType = -1, recPrecision = 0, recScale = 0,
+                    recNullable = 0;
+        SQLLEN recLength = 0;
+        ret = SQLGetDescRec(hIrd, e.col, recName, sizeof(recName), &recNameLen, &recType, &recSubType,
+                            &recLength, &recPrecision, &recScale, &recNullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+        EXPECT_EQ(recType, verboseType) << "column " << e.col;
+        EXPECT_EQ(recSubType, e.intervalCode) << "column " << e.col;
+    }
 }

--- a/tests/test_descriptor.cpp
+++ b/tests/test_descriptor.cpp
@@ -422,3 +422,79 @@ TEST_F(DescriptorTest, IrdRecordFieldsBeforePrepareAreHY007) {
     ret = SQLGetDescField(hIrd, 1, SQL_DESC_TYPE, &type, 0, NULL);
     ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
 }
+
+// ===== IRD records after SQLPrepare, before any bind or execute (#316) =====
+TEST_F(DescriptorTest, IrdRecordsDescribeColumnsAfterPrepare) {
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"SELECT CAST(1 AS INTEGER) AS INTCOL, CAST('x' AS VARCHAR(5)) AS VARCOL "
+                  "FROM RDB$DATABASE",
+        SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+
+    // Descriptor reads first, before anything binds or executes the columns
+    for (SQLSMALLINT col = 1; col <= 2; col++) {
+        SQLSMALLINT descType = 0, conciseType = 0;
+        SQLCHAR descName[64] = {};
+        SQLINTEGER nameLen = 0;
+        ret = SQLGetDescField(hIrd, col, SQL_DESC_TYPE, &descType, 0, NULL);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+        ret = SQLGetDescField(hIrd, col, SQL_DESC_CONCISE_TYPE, &conciseType, 0, NULL);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+        ret = SQLGetDescField(hIrd, col, SQL_DESC_NAME, descName, sizeof(descName), &nameLen);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+
+        SQLCHAR recName[64] = {};
+        SQLSMALLINT recNameLen = 0, recType = 0, recSubType = 0, recPrecision = 0, recScale = 0,
+                    recNullable = 0;
+        SQLLEN recLength = 0;
+        ret = SQLGetDescRec(hIrd, col, recName, sizeof(recName), &recNameLen, &recType, &recSubType,
+                            &recLength, &recPrecision, &recScale, &recNullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hIrd);
+
+        SQLCHAR colName[64] = {};
+        SQLSMALLINT colNameLen = 0, dataType = 0, decimalDigits = 0, nullable = 0;
+        SQLULEN columnSize = 0;
+        ret = SQLDescribeCol(hStmt, col, colName, sizeof(colName), &colNameLen, &dataType,
+                             &columnSize, &decimalDigits, &nullable);
+        ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+        EXPECT_NE(descType, SQL_C_DEFAULT) << "column " << col << " still holds the record default";
+        EXPECT_NE(conciseType, SQL_C_DEFAULT) << "column " << col;
+        EXPECT_STREQ((char*)descName, (char*)colName) << "column " << col;
+        EXPECT_NE(recType, SQL_C_DEFAULT) << "column " << col;
+        EXPECT_STREQ((char*)recName, (char*)colName) << "column " << col;
+        if (col == 1) {
+            EXPECT_EQ(descType, dataType) << "INTEGER column";
+            EXPECT_EQ(recType, dataType) << "INTEGER column";
+        }
+    }
+}
+
+TEST_F(DescriptorTest, CopyDescFromIrdAfterPrepare) {
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"SELECT CAST(1 AS INTEGER) AS INTCOL FROM RDB$DATABASE", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLHDESC hIrd = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_IMP_ROW_DESC, &hIrd, 0, NULL)));
+
+    SQLCHAR colName[64] = {};
+    SQLSMALLINT colNameLen = 0, dataType = 0, decimalDigits = 0, nullable = 0;
+    SQLULEN columnSize = 0;
+    ret = SQLDescribeCol(hStmt, 1, colName, sizeof(colName), &colNameLen, &dataType,
+                         &columnSize, &decimalDigits, &nullable);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    // Copy the IRD before anything binds or executes the column
+    SQLHDESC hCopy = SQL_NULL_HDESC;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLAllocHandle(SQL_HANDLE_DESC, hDbc, &hCopy)));
+    ret = SQLCopyDesc(hIrd, hCopy);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hCopy);
+
+    SQLSMALLINT descType = 0;
+    ret = SQLGetDescField(hCopy, 1, SQL_DESC_TYPE, &descType, 0, NULL);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_DESC, hCopy);
+    EXPECT_EQ(descType, dataType);
+    SQLFreeHandle(SQL_HANDLE_DESC, hCopy);
+}

--- a/tests/test_descriptor.cpp
+++ b/tests/test_descriptor.cpp
@@ -672,3 +672,25 @@ TEST_F(DescriptorTest, ColAttributeTypeFieldsFollowOdbc) {
         EXPECT_EQ(intervalCode, e.intervalCode) << "column " << e.col;
     }
 }
+
+// ===== SQLColAttribute writes its numeric attribute at full width (#316) =====
+TEST_F(DescriptorTest, ColAttributeNumericAttributeIsFullWidth) {
+    SQLRETURN ret = SQLPrepare(hStmt,
+        (SQLCHAR*)"SELECT CAST('x' AS VARCHAR(5)) AS A FROM RDB$DATABASE", SQL_NTS);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    SQLSMALLINT dataType = 0, decimalDigits = 0, nullable = 0;
+    SQLULEN columnSize = 0;
+    ret = SQLDescribeCol(hStmt, 1, NULL, 0, NULL, &dataType, &columnSize, &decimalDigits, &nullable);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+
+    // The same read into a zeroed and into an all-ones SQLLEN: a 32-bit write
+    // leaves the upper half of the second one set and the two differ, and a
+    // negative type code read from the zeroed one comes out as a large positive.
+    SQLLEN zeroed = 0, poisoned = -1;
+    ret = SQLColAttribute(hStmt, 1, SQL_DESC_CONCISE_TYPE, NULL, 0, NULL, &zeroed);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    ret = SQLColAttribute(hStmt, 1, SQL_DESC_CONCISE_TYPE, NULL, 0, NULL, &poisoned);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(zeroed, (SQLLEN)dataType);
+    EXPECT_EQ(poisoned, (SQLLEN)dataType);
+}

--- a/tests/test_scrollable_cursor.cpp
+++ b/tests/test_scrollable_cursor.cpp
@@ -193,3 +193,28 @@ TEST_F(ScrollableCursorTest, RewindAfterEnd) {
     ASSERT_TRUE(SQL_SUCCEEDED(ret));
     EXPECT_EQ(FetchID(), 1);
 }
+
+// ===== SQL_ATTR_KEYSET_SIZE is its own attribute, not the rowset size (#307) =====
+TEST_F(ScrollableCursorTest, KeysetSizeDoesNotChangeRowArraySize) {
+    SQLULEN v = 0;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_ROW_ARRAY_SIZE, &v, 0, NULL)));
+    EXPECT_EQ(v, 1u);
+
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ATTR_KEYSET_SIZE, (SQLPOINTER)7, 0)));
+    v = 0;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_ROW_ARRAY_SIZE, &v, 0, NULL)));
+    EXPECT_EQ(v, 1u) << "SQL_ATTR_KEYSET_SIZE must not touch the rowset size";
+    v = 0;
+    SQLRETURN ret = SQLGetStmtAttr(hStmt, SQL_ATTR_KEYSET_SIZE, &v, 0, NULL);
+    ASSERT_TRUE(SQL_SUCCEEDED(ret)) << GetOdbcError(SQL_HANDLE_STMT, hStmt);
+    EXPECT_EQ(v, 7u);
+
+    // The ODBC 2 name of the rowset size still sets it, and leaves the keyset size alone
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLSetStmtAttr(hStmt, SQL_ROWSET_SIZE, (SQLPOINTER)3, 0)));
+    v = 0;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_ROW_ARRAY_SIZE, &v, 0, NULL)));
+    EXPECT_EQ(v, 3u);
+    v = 0;
+    ASSERT_TRUE(SQL_SUCCEEDED(SQLGetStmtAttr(hStmt, SQL_ATTR_KEYSET_SIZE, &v, 0, NULL)));
+    EXPECT_EQ(v, 7u);
+}


### PR DESCRIPTION
Fixes #316. Builds on #314: its three commits show here until it merges (same function, same test file). This PR is the last ten commits.

A sweep of every path that reports column and parameter metadata (`SQLDescribeCol`, `SQLColAttribute`, `SQLGetDescField`, `SQLGetDescRec`, `SQLCopyDesc`, `SQLDescribeParam`, the IRD and the IPD) over seventeen Firebird column types, before and after binding, in both charsets, found the defects below. All of them are fixed here; the three items under "not changed" are conventions, listed with the reason.

## 1. Implementation records were empty until the first bind or execute

`SQLPrepare` sizes the IRD and the IPD but leaves their records at the constructor defaults: type `SQL_C_DEFAULT` (99) and no name. `defFromMetaDataOut` / `defFromMetaDataIn` fill a record only when the column or parameter is bound or the statement executes. `SQLDescribeCol`, `SQLColAttribute` and `SQLDescribeParam` read the statement metadata directly, so they were right, while `SQLGetDescField`, `SQLGetDescRec` and `SQLCopyDesc` on the same descriptors handed back 99, an empty name, nullable 0 and scale 0 with `SQL_SUCCESS`.

`defineImplRecord` fills an undefined record of either descriptor before any of the three paths reads or copies it, with the calls `SQLBindCol` and `SQLBindParameter` already make.

## 2. The type fields were the record's raw fields

An implementation record keeps the concise SQL type in `type` and the converter's C type in `conciseType`, and the getters handed those out as they are. Measured on the #314 driver after a bind: `SQL_DESC_CONCISE_TYPE` answered -16 for `INTEGER`, -25 for `BIGINT`, -8 for a UTF8 `VARCHAR` and 1 for a text `BLOB` while `SQLColAttribute` answered 4, -5, -9 and -1; `SQL_DESC_TYPE` answered the concise code (91, 93) for datetime columns instead of `SQL_DATETIME`; `SQL_DESC_DATETIME_INTERVAL_CODE` was always 0; `SQLGetDescRec` returned the same pair. The full matrix is in #316.

`sqlGetDescField` and `sqlGetDescRec` derive the verbose type, the concise type and the datetime interval code from the SQL type for both implementation descriptors. The record fields the converter reads are unchanged.

## 3. SQLColAttribute had the same two gaps

`SQL_DESC_TYPE` answered 91 for a `DATE` where the specification asks for `SQL_DATETIME`, and `SQL_DESC_DATETIME_INTERVAL_CODE` was rejected as an unknown field. Both now use the same helpers; `SQL_DESC_CONCISE_TYPE` is unchanged.

## 4. Three length fields were written as 32-bit integers

`SQLGetDescField` wrote `SQL_DESC_LENGTH`, `SQL_DESC_OCTET_LENGTH` and `SQL_DESC_DISPLAY_SIZE` as 32-bit integers into the application's `SQLULEN` / `SQLLEN`, leaving the upper half untouched on 64-bit builds. They are written at full width now.

## 5. SQLGetDescRec on an unprepared IRD answered HY091

Now `HY007`, as `SQLGetDescField` does since #314.

## 6. SQLColAttribute and SQLColAttributeW were not exported on Linux

The two entry points declared their numeric attribute as `SQLPOINTER` on every platform but 64-bit Windows, mirroring Microsoft's header. unixODBC declares it as `SQLLEN *`, so on Linux the compiler saw an overload rather than the `extern "C"` function from the header and exported both under C++ names; an ELF symbol scan of the CI build shows 112 of the 114 entry points with C linkage and exactly these two mangled. unixODBC therefore routed every `SQLColAttribute` call through the ODBC 2 `SQLColAttributesW` with `SQL_DESC_TYPE` mapped to `SQL_COLUMN_TYPE`, and the same `#ifdef` made the numeric attribute a 32-bit write on Linux x64: `SQL_DESC_CONCISE_TYPE` of a UTF8 `VARCHAR` read from a zeroed `SQLLEN` came back as 4294967287 instead of -9. The parameter is `SQLLEN *` except on 32-bit Windows now, and the value is written as an `SQLLEN` everywhere.

## Tests

Eight cases in `test_descriptor.cpp`: `IrdRecordsDescribeColumnsAfterPrepare`, `CopyDescFromIrdAfterPrepare`, `IrdTypeFieldsFollowOdbc`, `IpdRecordsDescribeParametersAfterPrepare`, `IrdLengthFieldsAreFullWidth`, `IrdGetDescRecBeforePrepareIsHY007`, `ColAttributeTypeFieldsFollowOdbc`, `ColAttributeNumericAttributeIsFullWidth`. The first seven fail against the #314 driver on Windows, the last one fails on Linux x64 against any earlier build, and pass with this branch. Full suite with this branch, `CHARSET=UTF8` and `NONE`: 399 ran, 234 passed, 165 skipped, 0 failed.

## Not changed, and why

- `SQLCopyDesc` from an implementation descriptor still copies the converter's C type into the target's concise type. ODBC's SQL and C codes coincide only for some types (`SQL_BIGINT` and `SQL_VARCHAR` have no C twin), so an application that copies the IRD into an ARD and fetches through it works today because of that; the copy's `SQL_DESC_TYPE` is the SQL type.
- `SQL_DESC_LENGTH` and `SQL_DESC_OCTET_LENGTH` for numeric and datetime columns are crossed between the two APIs: `SQLColAttribute` answers the display size for LENGTH (6 for `SMALLINT`) and the precision for OCTET_LENGTH (5), the descriptor answers the precision for LENGTH (5) and the display size for OCTET_LENGTH (6), and the specification's transfer octet length would be 2. Unifying them changes values applications size buffers with, so it needs a decision rather than a quiet fix; the descriptor side matches `SQLDescribeCol`'s column size today.
- `CHAR` and `VARCHAR` columns with `CHARACTER SET OCTETS` are reported as `SQL_CHAR` / `SQL_VARCHAR` (a 16-byte one as `SQL_GUID`, #296). Reporting them as `SQL_BINARY` / `SQL_VARBINARY` is the Firebird meaning, and an application-visible type change; same reason.
